### PR TITLE
Mami

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -86,15 +86,15 @@ import de.slikey.effectlib.EffectManager;
 public class MagicSpells extends JavaPlugin {
 
 	public static MagicSpells plugin;
-	
+
 	// Change this when you want to start tweaking the source and fixing bugs
 	public static Level DEVELOPER_DEBUG_LEVEL = Level.OFF;
-	
+
 	// Pass this to methods that want spell arguments passed but doesn't have any to be passed
 	public static final String[] NULL_ARGS = null;
-	
+
 	VolatileCodeHandle volatileCodeHandle;
-	
+
 	boolean debug;
 	boolean debugNull;
 	boolean debugNumberFormat;
@@ -103,15 +103,15 @@ public class MagicSpells extends JavaPlugin {
 	boolean enableProfiling;
 	ChatColor textColor;
 	int broadcastRange;
-	
+
 	boolean opsHaveAllSpells;
 	boolean defaultAllPermsFalse;
 	boolean ignoreGrantPerms;
 	boolean ignoreGrantPermsFakeValue;
 	boolean ignoreCastPerms;
-	
+
 	boolean enableTempGrantPerms = true;
-	
+
 	boolean separatePlayerSpellsPerWorld;
 	boolean allowCycleToNoSpell;
 	boolean alwaysShowMessageOnCycle;
@@ -135,16 +135,16 @@ public class MagicSpells extends JavaPlugin {
 	boolean checkWorldPvpFlag;
 	boolean checkScoreboardTeams;
 	boolean hidePredefinedItemTooltips;
-	
+
 	boolean enableManaBars;
 	int manaPotionCooldown;
 	String strManaPotionOnCooldown;
 	HashMap<ItemStack, Integer> manaPotions;
-	
+
 	String soundFailOnCooldown;
 	String soundFailMissingReagents;
 	String soundFailCantCast;
-	
+
 	// Strings
 	String strCastUsage;
 	String strUnknownSpell;
@@ -157,14 +157,14 @@ public class MagicSpells extends JavaPlugin {
 	String strCantBind;
 	String strConsoleName;
 	String strXpAutoLearned;
-	
+
 	// Spell containers
 	HashMap<String, Spell> spells; // Map internal names to spells
 	HashMap<String, Spell> spellNames; // Map configured names to spells
 	ArrayList<Spell> spellsOrdered; // Spells in loaded order
 	HashMap<String, Spellbook> spellbooks; // Player spellbooks
 	HashMap<String, Spell> incantations; // Map incantation strings to spells
-		
+
 	// Container vars
 	ManaHandler mana;
 	HashMap<Player, Long> manaPotionCooldowns;
@@ -178,31 +178,31 @@ public class MagicSpells extends JavaPlugin {
 	VariableManager variableManager;
 	MagicLogger magicLogger;
 	LifeLengthTracker lifeLengthTracker;
-	
+
 	MagicConfig config;
-	
+
 	// Profiling
 	HashMap<String, Long> profilingTotalTime;
 	HashMap<String, Integer> profilingRuns;
-	
+
 	public EffectManager effectManager;
-	
+
 	public boolean cycleSpellsOnOffhandAction;
-	
+
 	// Anticheat software integration
 	public boolean allowAnticheatIntegrations;
-	
+
 	@Override
 	public void onEnable() {
 		load();
-		
+
 		Metrics metrics = new Metrics(this);
 	}
-	
+
 	void load() {
 		plugin = this;
 		PluginManager pm = plugin.getServer().getPluginManager();
-		
+
 		effectManager = new EffectManager(this);
 		effectManager.enableDebug(debug);
 		try {
@@ -212,18 +212,18 @@ public class MagicSpells extends JavaPlugin {
 		} catch (Exception ignored) {
 			// No-op
 		}
-		
+
 		// Create storage stuff
 		spells = new HashMap<>();
 		spellNames = new HashMap<>();
 		spellsOrdered = new ArrayList<>();
 		spellbooks = new HashMap<>();
 		incantations = new HashMap<>();
-		
+
 		// Make sure directories are created
 		this.getDataFolder().mkdir();
 		new File(this.getDataFolder(), "spellbooks").mkdir();
-		
+
 		// Load config
 		if (!new File(getDataFolder(), "config.yml").exists() && !new File(getDataFolder(), "general.yml").exists()) {
 			saveResource("general.yml", false);
@@ -237,7 +237,7 @@ public class MagicSpells extends JavaPlugin {
 			MagicSpells.log(Level.SEVERE, "Error in config file, stopping config load");
 			return;
 		}
-		
+
 		// FIXME clean this up. a lot
 		boolean v1_9 = false;
 		if (config.getBoolean("general.enable-volatile-features", true)) {
@@ -294,17 +294,17 @@ public class MagicSpells extends JavaPlugin {
 			volatileCodeHandle = new VolatileCodeDisabled();
 		}
 		HandHandler.initialize();
-		
+
 		debug = config.getBoolean("general.debug", false);
 		debugNull = config.getBoolean("general.debug-null", true);
 		debugNumberFormat = config.getBoolean("general.debug-number-format", true);
 		debugLevel = config.getInt("general.debug-level", 3);
-		
+
 		enableErrorLogging = config.getBoolean("general.enable-error-logging", true);
 		enableProfiling = config.getBoolean("general.enable-profiling", false);
 		textColor = ChatColor.getByChar(config.getString("general.text-color", ChatColor.DARK_AQUA.getChar() + ""));
 		broadcastRange = config.getInt("general.broadcast-range", 20);
-		
+
 		opsHaveAllSpells = config.getBoolean("general.ops-have-all-spells", true);
 		defaultAllPermsFalse = config.getBoolean("general.default-all-perms-false", false);
 		ignoreGrantPerms = config.getBoolean("general.ignore-grant-perms", false);
@@ -335,7 +335,7 @@ public class MagicSpells extends JavaPlugin {
 		castOnAnimate = config.getBoolean("general.cast-on-animate", false);
 		useExpBarAsCastTimeBar = config.getBoolean("general.use-exp-bar-as-cast-time-bar", true);
 		cooldownsPersistThroughReload = config.getBoolean("general.cooldowns-persist-through-reload", true);
-		
+
 		entityNames = new HashMap<>();
 		if (config.contains("general.entity-names")) {
 			Set<String> keys = config.getSection("general.entity-names").getKeys(false);
@@ -350,7 +350,7 @@ public class MagicSpells extends JavaPlugin {
 		soundFailOnCooldown = config.getString("general.sound-on-cooldown", null);
 		soundFailMissingReagents = config.getString("general.sound-missing-reagents", null);
 		soundFailCantCast = config.getString("general.sound-cant-cast", null);
-		
+
 		strCastUsage = config.getString("general.str-cast-usage", "Usage: /cast <spell>. Use /cast list to see a list of spells.");
 		strUnknownSpell = config.getString("general.str-unknown-spell", "You do not know a spell with that name.");
 		strSpellChange = config.getString("general.str-spell-change", "You are now using the %s spell.");
@@ -362,13 +362,13 @@ public class MagicSpells extends JavaPlugin {
 		strWrongWorld = config.getString("general.str-wrong-world", "You cannot cast that spell here.");
 		strConsoleName = config.getString("general.console-name", "Admin");
 		strXpAutoLearned = config.getString("general.str-xp-auto-learned", "You have learned the %s spell!");
-		
+
 		allowAnticheatIntegrations = config.getBoolean("general.allow-anticheat-integrations", false);
-		
+
 		enableManaBars = config.getBoolean("mana.enable-mana-system", false);
 		manaPotionCooldown = config.getInt("mana.mana-potion-cooldown", 30);
 		strManaPotionOnCooldown = config.getString("mana.str-mana-potion-on-cooldown", "You cannot use another mana potion yet.");
-		
+
 		// Create handling objects
 		if (enableManaBars) mana = new ManaSystem(config);
 		noMagicZones = new NoMagicZoneManager();
@@ -382,10 +382,10 @@ public class MagicSpells extends JavaPlugin {
 		itemNameResolver = new MagicItemNameResolver();
 		if (CompatBasics.pluginEnabled("Vault")) moneyHandler = new MoneyHandler();
 		lifeLengthTracker = new LifeLengthTracker();
-		
+
 		// Call loading event
 		pm.callEvent(new MagicSpellsLoadingEvent(this));
-				
+
 		// Init permissions
 		log("Initializing permissions");
 		boolean opsIgnoreReagents = config.getBoolean("general.ops-ignore-reagents", true);
@@ -400,7 +400,7 @@ public class MagicSpells extends JavaPlugin {
 		HashMap<String, Boolean> permLearnChildren = new HashMap<>();
 		HashMap<String, Boolean> permCastChildren = new HashMap<>();
 		HashMap<String, Boolean> permTeachChildren = new HashMap<>();
-		
+
 		// Load predefined items
 		log("Loading predefined items...");
 		hidePredefinedItemTooltips = config.getBoolean("general.hide-predefined-items-tooltips", false);
@@ -439,7 +439,7 @@ public class MagicSpells extends JavaPlugin {
 			}
 		}
 		log("..." + Util.predefinedItems.size() + " predefined items loaded");
-		
+
 		// Load variables
 		log("Loading variables...");
 		ConfigurationSection varSec = null;
@@ -448,7 +448,7 @@ public class MagicSpells extends JavaPlugin {
 		}
 		variableManager = new VariableManager(this, varSec);
 		log("..." + variableManager.count() + " variables loaded");
-		
+
 		// Load spells
 		log("Loading spells...");
 		loadSpells(config, pm, permGrantChildren, permLearnChildren, permCastChildren, permTeachChildren);
@@ -457,14 +457,14 @@ public class MagicSpells extends JavaPlugin {
 			MagicSpells.error("No spells loaded!");
 			return;
 		}
-		
+
 		log("Finalizing perms...");
 		// Finalize spell permissions
 		addPermission(pm, "grant.*", PermissionDefault.FALSE, permGrantChildren);
 		addPermission(pm, "learn.*", defaultAllPermsFalse ? PermissionDefault.FALSE : PermissionDefault.TRUE, permLearnChildren);
 		addPermission(pm, "cast.*", defaultAllPermsFalse ? PermissionDefault.FALSE : PermissionDefault.TRUE, permCastChildren);
 		addPermission(pm, "teach.*", defaultAllPermsFalse ? PermissionDefault.FALSE : PermissionDefault.TRUE, permTeachChildren);
-		
+
 		// Advanced perms
 		addPermission(pm, "advanced.list", PermissionDefault.FALSE);
 		addPermission(pm, "advanced.forget", PermissionDefault.FALSE);
@@ -475,14 +475,14 @@ public class MagicSpells extends JavaPlugin {
 		advancedPermChildren.put(Perm.ADVANCED_SCROLL.getNode(), true);
 		addPermission(pm, "advanced.*", defaultAllPermsFalse? PermissionDefault.FALSE : PermissionDefault.OP, advancedPermChildren);
 		log("...done");
-		
+
 		// Load xp system
 		if (config.getBoolean("general.enable-magic-xp", false)) {
 			log("Loading xp system...");
 			magicXpHandler = new MagicXpHandler(this, config);
 			log("...xp system loaded");
 		}
-		
+
 		// Load in-game spell names, incantations, and initialize spells
 		log("Initializing spells...");
 		for (Spell spell : spells.values()) {
@@ -505,12 +505,12 @@ public class MagicSpells extends JavaPlugin {
 			spell.initialize();
 		}
 		log("...done");
-		
+
 		// Load online player spellbooks
 		log("Loading online player spellbooks...");
 		Util.forEachPlayerOnline(p -> spellbooks.put(p.getName(), new Spellbook(p, this)));
 		log("...done");
-		
+
 		// Initialize passive manager
 		log("Initializing passive manager...");
 		PassiveManager passiveManager = PassiveSpell.getManager();
@@ -518,7 +518,7 @@ public class MagicSpells extends JavaPlugin {
 			passiveManager.initialize();
 		}
 		log("...done");
-		
+
 		// Load saved cooldowns
 		if (cooldownsPersistThroughReload) {
 			File file = new File(getDataFolder(), "cooldowns.txt");
@@ -548,16 +548,16 @@ public class MagicSpells extends JavaPlugin {
 			}
 			log("Restored cooldowns");
 		}
-		
+
 		// Setup mana
 		if (enableManaBars) {
 			log("Enabling mana bars...");
 			// Init
 			mana.initialize();
-			
+
 			// Setup online player mana bars
 			Util.forEachPlayerOnline(p -> mana.createManaBar(p));
-			
+
 			// Load mana potions
 			List<String> manaPots = config.getStringList("mana.mana-potions", null);
 			if (manaPots != null && !manaPots.isEmpty()) {
@@ -579,13 +579,13 @@ public class MagicSpells extends JavaPlugin {
 			}
 			log("...done");
 		}
-		
+
 		// Load no-magic zones
 		noMagicZones.load(config);
 		if (noMagicZones.zoneCount() == 0) {
 			noMagicZones = null;
 		}
-		
+
 		// Load listeners
 		log("Loading cast listeners...");
 		registerEvents(new MagicPlayerListener(this));
@@ -607,33 +607,33 @@ public class MagicSpells extends JavaPlugin {
 		}
 		ModifierSet.initializeModifierListeners();
 		log("...done");
-		
+
 		// Initialize logger
 		boolean enableLogging = config.getBoolean("general.enable-logging", false);
 		if (enableLogging || debug) {
 			magicLogger = new MagicLogger(this, debug, enableLogging);
 		}
-		
+
 		// Register commands
 		CastCommand exec = new CastCommand(this, config.getBoolean("general.enable-tab-completion", true));
 		getCommand("magicspellcast").setExecutor(exec);
 		getCommand("magicspellmana").setExecutor(exec);
 		getCommand("magicspellxp").setExecutor(exec);
-		
+
 		// Setup profiling
 		if (enableProfiling) {
 			profilingTotalTime = new HashMap<>();
 			profilingRuns = new HashMap<>();
 		}
-		
+
 		CompatBasics.setupExemptionAssistant();
-		
+
 		// Call loaded event
 		pm.callEvent(new MagicSpellsLoadedEvent(this));
-		
+
 		log("MagicSpells loading complete!");
 	}
-	
+
 	private static final int LONG_LOAD_THRESHOLD = 50;
 	// DEBUG INFO: level 2, loaded spell spellname
 	private void loadSpells(MagicConfig config, PluginManager pm, HashMap<String, Boolean> permGrantChildren, HashMap<String, Boolean> permLearnChildren, HashMap<String, Boolean> permCastChildren, HashMap<String, Boolean> permTeachChildren) {
@@ -648,7 +648,7 @@ public class MagicSpells extends JavaPlugin {
 		// Create class loader
 		URL[] urls = new URL[jarList.size() + 1];
 		ClassLoader cl = getClassLoader();
-		try {		
+		try {
 			urls[0] = getDataFolder().toURI().toURL();
 			for(int i = 1; i <= jarList.size(); i++) {
 				urls[i] = jarList.get(i - 1).toURI().toURL();
@@ -657,7 +657,7 @@ public class MagicSpells extends JavaPlugin {
 		} catch (MalformedURLException e) {
 			e.printStackTrace();
 		}
-		
+
 		// Get spells from config
 		Set<String> spellKeys = config.getSpellKeys();
 		if (spellKeys == null) return;
@@ -687,7 +687,7 @@ public class MagicSpells extends JavaPlugin {
 					Spell spell = constructor.newInstance(config, spellName);
 					spells.put(spellName.toLowerCase(), spell);
 					spellsOrdered.add(spell);
-					
+
 					// Add permissions
 					if (!spell.isHelperSpell()) {
 						String permName = spell.getPermissionName();
@@ -705,10 +705,10 @@ public class MagicSpells extends JavaPlugin {
 						permCastChildren.put(Perm.CAST.getNode() + permName, true);
 						permTeachChildren.put(Perm.TEACH.getNode() + permName, true);
 					}
-					
+
 					// Done
 					debug(2, "Loaded spell: " + spellName);
-					
+
 				} catch (ClassNotFoundException e) {
 					error("Unable to load spell " + spellName + " (missing class " + className + ')');
 				} catch (NoSuchMethodException e) {
@@ -722,19 +722,19 @@ public class MagicSpells extends JavaPlugin {
 			}
 		}
 	}
-	
+
 	private void addPermission(PluginManager pm, String perm, PermissionDefault permDefault) {
 		addPermission(pm, perm, permDefault, null, null);
 	}
-	
+
 	private void addPermission(PluginManager pm, String perm, PermissionDefault permDefault, String description) {
 		addPermission(pm, perm, permDefault, null, description);
 	}
-	
+
 	private void addPermission(PluginManager pm, String perm, PermissionDefault permDefault, Map<String,Boolean> children) {
 		addPermission(pm, perm, permDefault, children, null);
 	}
-	
+
 	private void addPermission(PluginManager pm, String perm, PermissionDefault permDefault, Map<String,Boolean> children, String description) {
 		if (pm.getPermission("magicspells." + perm) == null) {
 			if (description == null) {
@@ -744,7 +744,7 @@ public class MagicSpells extends JavaPlugin {
 			}
 		}
 	}
-	
+
 	/**
 	 * Gets the instance of the MagicSpells plugin
 	 * @return the MagicSpells plugin
@@ -752,7 +752,7 @@ public class MagicSpells extends JavaPlugin {
 	public static MagicSpells getInstance() {
 		return plugin;
 	}
-	
+
 	/**
 	 * Gets all the spells currently loaded
 	 * @return a Collection of Spell objects
@@ -760,7 +760,7 @@ public class MagicSpells extends JavaPlugin {
 	public static Collection<Spell> spells() {
 		return plugin.spells.values();
 	}
-	
+
 	/**
 	 * Gets a spell by its internal name (the key name in the config file)
 	 * @param spellName the internal name of the spell to find
@@ -769,7 +769,7 @@ public class MagicSpells extends JavaPlugin {
 	public static Spell getSpellByInternalName(String spellName) {
 		return plugin.spells.get(spellName.toLowerCase());
 	}
-	
+
 	/**
 	 * Gets a spell by its in-game name (the name specified with the 'name' config option)
 	 * @param spellName the in-game name of the spell to find
@@ -778,9 +778,9 @@ public class MagicSpells extends JavaPlugin {
 	public static Spell getSpellByInGameName(String spellName) {
 		return plugin.spellNames.get(spellName.toLowerCase());
 	}
-	
+
 	/**
-	 * Gets a player's spellbook, which contains known spells and handles spell permissions. 
+	 * Gets a player's spellbook, which contains known spells and handles spell permissions.
 	 * If a player does not have a spellbook, one will be created.
 	 * @param player the player to get a spellbook for
 	 * @return the player's spellbook
@@ -790,7 +790,7 @@ public class MagicSpells extends JavaPlugin {
 		if (spellbook == null) throw new IllegalStateException();
 		return spellbook;
 	}
-	
+
 	public static int getDebugLevel() {
 		return plugin.debugLevel;
 	}
@@ -798,7 +798,7 @@ public class MagicSpells extends JavaPlugin {
 	public static ChatColor getTextColor() {
 		return plugin.textColor;
 	}
-	
+
 	/**
 	 * Gets a list of blocks that are considered transparent
 	 * @return list of block types
@@ -806,7 +806,7 @@ public class MagicSpells extends JavaPlugin {
 	public static HashSet<Material> getTransparentBlocks() {
 		return plugin.losTransparentBlocks;
 	}
-	
+
 	/**
 	 * Gets a map of entity types and their configured names, to be used when sending messages to players
 	 * @return the map
@@ -814,7 +814,7 @@ public class MagicSpells extends JavaPlugin {
 	public static HashMap<EntityType, String> getEntityNames() {
 		return plugin.entityNames;
 	}
-	
+
 	/**
 	 * Checks whether to ignore the durability on the given type when using it as a cast item.
 	 * @param type the type to check
@@ -823,27 +823,27 @@ public class MagicSpells extends JavaPlugin {
 	public static boolean ignoreCastItemDurability(int type) {
 		return plugin.ignoreCastItemDurability != null && plugin.ignoreCastItemDurability.contains(type);
 	}
-	
+
 	public static boolean ignoreCastItemEnchants() {
 		return plugin.ignoreCastItemEnchants;
 	}
-	
+
 	public static boolean ignoreCastItemNames() {
 		return plugin.ignoreCastItemNames;
 	}
-	
+
 	public static boolean ignoreCastItemNameColors() {
 		return plugin.ignoreCastItemNameColors;
 	}
-	
+
 	public static boolean showStrCostOnMissingReagents() {
 		return plugin.showStrCostOnMissingReagents;
 	}
-	
+
 	public static boolean hidePredefinedItemTooltips() {
 		return plugin.hidePredefinedItemTooltips;
 	}
-	
+
 	/**
 	 * Gets the handler for no-magic zones.
 	 * @return the no-magic zone handler
@@ -851,11 +851,11 @@ public class MagicSpells extends JavaPlugin {
 	public static NoMagicZoneManager getNoMagicZoneManager() {
 		return plugin.noMagicZones;
 	}
-	
+
 	public static BuffManager getBuffManager() {
 		return plugin.buffManager;
 	}
-	
+
 	/**
 	 * Gets the mana handler, which handles all mana transactions.
 	 * @return the mana handler
@@ -863,7 +863,7 @@ public class MagicSpells extends JavaPlugin {
 	public static ManaHandler getManaHandler() {
 		return plugin.mana;
 	}
-	
+
 	/**
 	 * Sets the mana handler, which handles all mana transactions.
 	 * @param handler the mana handler
@@ -872,43 +872,43 @@ public class MagicSpells extends JavaPlugin {
 		plugin.mana.turnOff();
 		plugin.mana = handler;
 	}
-	
+
 	public static VolatileCodeHandle getVolatileCodeHandler() {
 		return plugin.volatileCodeHandle;
 	}
-	
+
 	public static ExperienceBarManager getExpBarManager() {
 		return plugin.expBarManager;
 	}
-	
+
 	public static BossBarManager getBossBarManager() {
 		return plugin.bossBarManager;
 	}
-	
+
 	public static ItemNameResolver getItemNameResolver() {
 		return plugin.itemNameResolver;
 	}
-	
+
 	public static void setItemNameResolver(ItemNameResolver resolver) {
 		plugin.itemNameResolver = resolver;
 	}
-	
+
 	public static MoneyHandler getMoneyHandler() {
 		return plugin.moneyHandler;
 	}
-	
+
 	public static MagicXpHandler getMagicXpHandler() {
 		return plugin.magicXpHandler;
 	}
-	
+
 	public static VariableManager getVariableManager() {
 		return plugin.variableManager;
 	}
-	
+
 	public static LifeLengthTracker getLifeLengthTracker() {
 		return plugin.lifeLengthTracker;
 	}
-	
+
 	/**
 	 * Formats a string by performing the specified replacements.
 	 * @param message the string to format
@@ -917,11 +917,11 @@ public class MagicSpells extends JavaPlugin {
 	 */
 	public static String formatMessage(String message, String... replacements) {
 		if (message == null) return null;
-		
+
 		String msg = message;
 		for (int i = 0; i < replacements.length; i += 2) {
 			if (replacements[i] == null) continue;
-			
+
 			if (replacements[i + 1] != null) {
 				msg = msg.replace(replacements[i], replacements[i + 1]);
 			} else {
@@ -930,7 +930,7 @@ public class MagicSpells extends JavaPlugin {
 		}
 		return msg;
 	}
-	
+
 	/**
 	 * Sends a message to a player, first making the specified replacements. This method also does color replacement and has multi-line functionality.
 	 * @param player the player to send the message to
@@ -940,11 +940,11 @@ public class MagicSpells extends JavaPlugin {
 	public static void sendMessageAndFormat(Player player, String message, String... replacements) {
 		sendMessage(formatMessage(message, replacements), player, null);
 	}
-	
+
 	public static void sendMessage(Player player, String message) {
 		sendMessage(message, player, null);
 	}
-	
+
 	/**
 	 * Sends a message to a player. This method also does color replacement and has multi-line functionality.
 	 * @param player the player to send the message to
@@ -971,10 +971,11 @@ public class MagicSpells extends JavaPlugin {
 					MagicSpells.plugin.sendMessage(p, message);
 				}
 			}
+			log(Level.INFO, message);
 		}
 	}
-	
-	private static Pattern chatVarMatchPattern = Pattern.compile("%var:[A-Za-z0-9_]+(:[0-9]+)?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);		
+
+	private static Pattern chatVarMatchPattern = Pattern.compile("%var:[A-Za-z0-9_]+(:[0-9]+)?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	public static String doSubjectVariableReplacements(Player player, String string) {
 		if (string != null && plugin.variableManager != null && string.contains("%var")) {
 			Matcher matcher = chatVarMatchPattern.matcher(string);
@@ -988,8 +989,8 @@ public class MagicSpells extends JavaPlugin {
 		}
 		return string;
 	}
-	
-	private static Pattern chatPlayerVarMatchPattern = Pattern.compile("%playervar:" + RegexUtil.USERNAME_REGEXP + ":[A-Za-z0-9_]+(:[0-9]+)?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);		
+
+	private static Pattern chatPlayerVarMatchPattern = Pattern.compile("%playervar:" + RegexUtil.USERNAME_REGEXP + ":[A-Za-z0-9_]+(:[0-9]+)?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	public static String doVariableReplacements(Player player, String string) {
 		string = doSubjectVariableReplacements(player, string);
 		if (string != null && plugin.variableManager != null && string.contains("%playervar")) {
@@ -1005,7 +1006,7 @@ public class MagicSpells extends JavaPlugin {
 		}
 		return string;
 	}
-	
+
 	//%arg:(index):defaultValue%
 	private static Pattern argumentSubstitutionPattern = Pattern.compile("%arg:[0-9]+:[0-9a-zA-Z_]+%");
 	public static String doArgumentSubstitution(String string, String[] args) {
@@ -1026,15 +1027,15 @@ public class MagicSpells extends JavaPlugin {
 		}
 		return string;
 	}
-	
+
 	public static String doArgumentAndVariableSubstitution(String string, Player player, String[] args) {
 		return doVariableReplacements(player, doArgumentSubstitution(string, args));
 	}
-	
+
 	public static void registerEvents(final Listener listener) {
 		registerEvents(listener, EventPriority.NORMAL);
 	}
-	
+
 	public static void registerEvents(final Listener listener, EventPriority customPriority) {
 		if (customPriority == null) customPriority = EventPriority.NORMAL;
 		Method[] methods;
@@ -1049,9 +1050,9 @@ public class MagicSpells extends JavaPlugin {
             final EventHandler eh = method.getAnnotation(EventHandler.class);
             if (eh == null) continue;
             EventPriority priority = eh.priority();
-            
+
             if (hasAnnotation(method, OverridePriority.class)) priority = customPriority;
-            
+
             final Class<?> checkClass = method.getParameterTypes()[0];
             if (!Event.class.isAssignableFrom(checkClass) || method.getParameterTypes().length != 1) {
                 plugin.getLogger().severe("Wrong method arguments used for event type registered");
@@ -1061,7 +1062,7 @@ public class MagicSpells extends JavaPlugin {
             method.setAccessible(true);
             EventExecutor executor = new EventExecutor() {
             	final String eventKey = plugin.enableProfiling ? "Event:" + listener.getClass().getName().replace("com.nisovin.magicspells.","") + '.' + method.getName() + '(' + eventClass.getSimpleName() + ')' : null;
-                
+
             	@Override
             	public void execute(Listener listener, Event event) {
                     try {
@@ -1088,11 +1089,11 @@ public class MagicSpells extends JavaPlugin {
             plugin.getServer().getPluginManager().registerEvent(eventClass, listener, priority, executor, plugin, eh.ignoreCancelled());
         }
 	}
-	
+
 	private static boolean hasAnnotation(Method m, Class<? extends Annotation> clazz) {
 		return m.getAnnotation(clazz) != null;
 	}
-	
+
 	public static int scheduleDelayedTask(final Runnable task, int delay) {
 		return Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, !plugin.enableErrorLogging ? task : new Runnable() {
 			@Override
@@ -1105,7 +1106,7 @@ public class MagicSpells extends JavaPlugin {
 			}
 		}, delay);
 	}
-	
+
 	public static int scheduleRepeatingTask(final Runnable task, int delay, int interval) {
 		return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, !plugin.enableErrorLogging ? task : new Runnable() {
 			@Override
@@ -1118,11 +1119,11 @@ public class MagicSpells extends JavaPlugin {
 			}
 		}, delay, interval);
 	}
-	
+
 	public static void cancelTask(int taskId) {
 		Bukkit.getScheduler().cancelTask(taskId);
 	}
-	
+
 	public static void handleException(Exception ex) {
 		if (plugin.enableErrorLogging) {
 			plugin.getLogger().severe("AN EXCEPTION HAS OCCURED:");
@@ -1152,7 +1153,7 @@ public class MagicSpells extends JavaPlugin {
 			ex.printStackTrace();
 		}
 	}
-	
+
 	static void profilingReport() {
 		if (plugin.profilingTotalTime != null && plugin.profilingRuns != null) {
 			PrintWriter writer = null;
@@ -1178,7 +1179,7 @@ public class MagicSpells extends JavaPlugin {
 			plugin.profilingRuns.clear();
 		}
 	}
-	
+
 	/**
 	 * Writes a debug message to the console if the debug option is enabled.
 	 * Uses debug level 2.
@@ -1187,7 +1188,7 @@ public class MagicSpells extends JavaPlugin {
 	public static void debug(String message) {
 		debug(2, message);
 	}
-	
+
 	/**
 	 * Writes a debug message to the console if the debug option is enabled.
 	 * @param level the debug level to log with
@@ -1198,16 +1199,16 @@ public class MagicSpells extends JavaPlugin {
 			log(Level.INFO, message);
 		}
 	}
-	
+
 	public static void log(String message) {
 		log(Level.INFO, message);
 	}
-	
+
 	public static void error(String message) {
 		log(Level.WARNING, message);
 		sendDebugMessage("&4MagicSpells error: &c" + message);
 	}
-	
+
 	/**
 	 * Writes an error message to the console.
 	 * @param level the error level
@@ -1216,11 +1217,11 @@ public class MagicSpells extends JavaPlugin {
 	public static void log(Level level, String message) {
 		plugin.getLogger().log(level, message);
 	}
-	
+
 	public static boolean profilingEnabled() {
 		return plugin.enableProfiling;
 	}
-	
+
 	public static void addProfile(String key, long time) {
         if (plugin.enableProfiling) {
         	Long total = plugin.profilingTotalTime.get(key);
@@ -1233,7 +1234,7 @@ public class MagicSpells extends JavaPlugin {
         	plugin.profilingRuns.put(key, runs);
         }
 	}
-	
+
 	/**
 	 * Teaches a player a spell (adds it to their spellbook)
 	 * @param player the player to teach
@@ -1246,28 +1247,28 @@ public class MagicSpells extends JavaPlugin {
 			spell = plugin.spells.get(spellName.toLowerCase());
 			if (spell == null) return false;
 		}
-		
+
 		Spellbook spellbook = getSpellbook(player);
-		
+
 		if (spellbook == null || spellbook.hasSpell(spell) || !spellbook.canLearn(spell)) return false;
-		
+
 		// Call event
 		SpellLearnEvent event = new SpellLearnEvent(spell, player, LearnSource.OTHER, null);
 		EventUtil.call(event);
 		if (event.isCancelled()) return false;
-		
+
 		spellbook.addSpell(spell);
 		spellbook.save();
 		return true;
 	}
-	
+
 	void unload() {
 		// Turn off spells
 		for (Spell spell : spells.values()) {
 			spell.turnOff();
 		}
 		PassiveSpell.resetManager();
-		
+
 		// Save cooldowns
 		if (cooldownsPersistThroughReload) {
 			File file = new File(getDataFolder(), "cooldowns.txt");
@@ -1289,13 +1290,13 @@ public class MagicSpells extends JavaPlugin {
 				file.delete();
 			}
 		}
-		
+
 		// Turn off buff manager
 		if (buffManager != null) {
 			buffManager.turnOff();
 			buffManager = null;
 		}
-		
+
 		// Clear memory
 		spells.clear();
 		spells = null;
@@ -1353,21 +1354,21 @@ public class MagicSpells extends JavaPlugin {
 		strWrongWorld = null;
 		strCantBind = null;
 		strConsoleName = null;
-		
+
 		config = null;
-		
+
 		// Remove star permissions (to allow new spells to be added to them)
 		getServer().getPluginManager().removePermission("magicspells.grant.*");
 		getServer().getPluginManager().removePermission("magicspells.cast.*");
 		getServer().getPluginManager().removePermission("magicspells.learn.*");
 		getServer().getPluginManager().removePermission("magicspells.teach.*");
-		
+
 		// Unregister all listeners
 		HandlerList.unregisterAll(this);
-		
+
 		// Cancel all tasks
 		Bukkit.getScheduler().cancelTasks(this);
-		
+
 		plugin = null;
 		effectManager.dispose();
 		effectManager = null;
@@ -1375,27 +1376,27 @@ public class MagicSpells extends JavaPlugin {
 		PromptType.unloadDestructPromptData();
 		CompatBasics.destructExemptionAssistant();
 	}
-	
+
 	@Override
-	public void onDisable() {	
+	public void onDisable() {
 		unload();
 	}
-	
+
 	public ClassLoader getPluginClassLoader() {
 		return getClassLoader();
 	}
-	
+
 	public MagicConfig getMagicConfig() {
 		return config;
 	}
-	
+
 }
 
 /*
  * TODO:
- * 
+ *
  * - Use MagicPlayer (Caster/PlayerCaster) across the entire plugin
  * - Allow spells to be cast by something other than players, like blocks and other entities
  * - Move NoMagicZoneWorldGuard and NoMagicZoneResidence outside of the core plugin
- * 
+ *
  */

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
@@ -187,5 +187,7 @@ public abstract class Condition {
 		conditions.put("nbtexists", NBTExists.class);
 		conditions.put("nbtdebug", NBTDebug.class);
 		conditions.put("nbtmatches", NBTMatches.class);
+		conditions.put("nbtexpr", NBTExpr.class);
+		conditions.put("nbtexpression", NBTExpr.class);
 	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTDebug.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTDebug.java
@@ -27,7 +27,11 @@ public class NBTDebug extends Condition {
 
 	@Override
 	public boolean setVar(String var) {
-		key = var.split("-");
+		key = var.split(".");
+		if(key.length == 0) {
+			String[] t = {var};
+			key = t;
+		}
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTEquals.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTEquals.java
@@ -30,7 +30,11 @@ public class NBTEquals extends Condition {
 	public boolean setVar(String var) {
 		try {
 			String[] data = var.split(":");
-			key = data[0].split("-");
+			key = data[0].split(".");
+			if(key.length == 0) {
+				String[] t = {data[0]};
+				key = t;
+			}
 			val = Double.parseDouble(data[1]);
 			return true;
 		} catch (NumberFormatException e) {
@@ -67,7 +71,7 @@ public class NBTEquals extends Condition {
 		if(succ) {
 			if(compound.hasKey(key[key.length - 1])) {
 				double test = compound.getDouble(key[key.length - 1]);
-				return test == val;
+				return Math.abs(test - val) < .00001;
 			}
 		}
 		// MagicSpells.sendDebugMessage(key + " : " + false);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTExists.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTExists.java
@@ -27,7 +27,11 @@ public class NBTExists extends Condition {
 
 	@Override
 	public boolean setVar(String var) {
-		key = var.split("-");
+		key = var.split(".");
+		if(key.length == 0) {
+			String[] t = {var};
+			key = t;
+		}
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTExpr.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTExpr.java
@@ -1,0 +1,504 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+//By Mami
+// This is the complete abstract syntax for an nbt expression:
+// <expr> ::= <and>
+// <and> ::= <or>&<or>; <or>
+// <or> ::= <not>|<not>; <not>
+// <not> ::= !<not>; (<and>); <op>
+// <op> ::= <comp>; <exists>
+// <comp> ::= <key>=<string>; <key>=<numeral>; <key>><numeral>; <key><<numeral>
+// <key> ::= <string>.<key>; <string>[<numeral>]
+// <exists> ::= <string>.<exists>; <string>[<numeral>]; <string>[<and>]
+// <numeral> can be any string that can parse as a double in java
+// <string> can be any string with backslash escapes for symbols (\&, \., \=, \\, etc.)
+// DO NOT PUT WHITESPACE CHARACTERS OR TICK MARKS (' or ") INTO AN NBT EXPR, THIS WILL BREAK MAGICSPELLS PARSING EVEN IF YOU ESCAPE THEM
+
+import org.bukkit.ChatColor;
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+
+//THESE IMPORTS HERE ARE VOLATILE, THE CORRECT VERSION OF MINECRAFT MUST BE USED
+//currently configured only for 1.12 mc
+import org.bukkit.craftbukkit.v1_12_R1.entity.CraftLivingEntity;
+import net.minecraft.server.v1_12_R1.NBTBase;
+import net.minecraft.server.v1_12_R1.NBTTagCompound;
+import net.minecraft.server.v1_12_R1.NBTTagList;
+import net.minecraft.server.v1_12_R1.EntityLiving;
+
+import com.nisovin.magicspells.DebugHandler;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+
+import java.util.Objects;
+import java.util.ArrayList;
+
+public class NBTExpr extends Condition {
+
+	public enum ASTType {
+		EXISTS, GT, LT, EQ, STREQ,//nbt operation types
+		KEY, INDEX, FIND,//nbt indexing types
+		AND, OR, NOT//expression operation types
+	}
+	public class NBTExpr_AST {
+		public ASTType type;
+		public String str;
+		public double numeral;
+		public NBTExpr_AST child0;
+		public NBTExpr_AST child1;
+	}
+	public NBTExpr_AST config_ast;
+
+	public interface ParseFunc {
+		public NBTExpr_AST func(ArrayList<String> tokens, int[] token_i, String[] error_msg);
+	}
+
+	//All of the lexing and parsing code here was cannibalised from my own lexing and parsing code from an old project
+	ArrayList<String> lex(String source, String[] error_msg) {
+		//incredibly lazy lexing, hopefully this does not cause issues in the future
+		//the proper way to do this is to track a DFA state while lexing and then store that state information with each token
+		ArrayList<String> tokens = new ArrayList<String>();
+		int i = 0;
+		String word = null;
+		while(i < source.length()) {
+			char ch = source.charAt(i);
+			if (ch == '\\') {
+				i += 1;
+				if(i >= source.length()) break;
+				ch = source.charAt(i);
+				if(word == null) {
+					word = "_" + ch;
+				} else {
+					word += ch;
+				}
+			} else if (ch == '.' || ch == '[' || ch == ']' || ch == '(' || ch == ')' || ch == '=' || ch == '<' || ch == '>' || ch == '&' || ch == '|' || ch == '!') {
+				if(word != null) {
+					tokens.add(word);
+					word = null;
+				}
+				tokens.add("" + ch);
+			} else if(ch == ' ' || ch == '\t' || ch == '\n') {
+				if(word != null) {
+					tokens.add(word);
+					word = null;
+				}
+			} else if('0' <= ch && ch <= '9') {
+				//lazy implementation of numeral lexing, the proper way to do this is by tracking a DFA state while lexing
+				String num = "";
+				while(i < source.length()) {
+					ch = source.charAt(i);
+					if(('0' <= ch && ch <= '9') || ch == '.') {
+						num = num + ch;
+						i += 1;
+					} else {
+						i -= 1;
+						break;
+					}
+				}
+				if(word != null) {
+					tokens.add(word);
+					word = null;
+				}
+				tokens.add(num);
+			} else if(word == null) {
+				word = "_" + ch;//all nbt keys are marked with _ prefixes, this is lazy, better to store a DFA state with the token
+			} else {
+				word += ch;
+			}
+			i += 1;
+		}
+		if (word != null) {
+			tokens.add(word);
+			word = null;
+		}
+		tokens.add("\n");//marks end of expr
+		return tokens;
+	}
+
+	String msg_unexpected(String unexpected, String expected) {
+		if(unexpected.equals("\n")) {
+			unexpected = "End of Expression";
+		} else if(unexpected.charAt(0) == '_') {
+			unexpected = unexpected.substring(1, unexpected.length());
+		}
+		return "NBTExpr syntax error: Unexpected token, expected " + expected + "; got " + unexpected;
+	}
+
+	boolean eat_token(ArrayList<String> tokens, int[] token_i, String str) {
+		if(str.equals(tokens.get(token_i[0]))) {
+			token_i[0] += 1;
+			return true;
+		} else {
+			return false;
+		}
+	}
+
+	NBTExpr_AST parse_left_binops_loop_(NBTExpr_AST left_node, ArrayList<String> tokens, int[] token_i, String[] error_msg, String[] op_strings, ASTType[] op_types, ParseFunc parse_lower) {
+		int binop_i = -1;
+		for(int i = 0; i < op_strings.length; i++) {
+			if(eat_token(tokens, token_i, op_strings[i])) {
+				binop_i = i;
+				break;
+			}
+		}
+		if(binop_i < 0) return left_node;
+
+		NBTExpr_AST right_node = parse_lower.func(tokens, token_i, error_msg);
+		if(right_node == null) return null;
+		NBTExpr_AST new_node = new NBTExpr_AST();
+		new_node.type = op_types[binop_i];
+		new_node.child0 = left_node;
+		new_node.child1 = right_node;
+		return parse_left_binops_loop_(new_node, tokens, token_i, error_msg, op_strings, op_types, parse_lower);
+	}
+	NBTExpr_AST parse_left_binops(ArrayList<String> tokens, int[] token_i, String[] error_msg, String[] op_strings, ASTType[] op_types, ParseFunc parse_lower) {
+		NBTExpr_AST node = parse_lower.func(tokens, token_i, error_msg);
+		if(node == null) return null;
+		return parse_left_binops_loop_(node, tokens, token_i, error_msg, op_strings, op_types, parse_lower);
+	}
+
+
+
+	NBTExpr_AST parse_key(ArrayList<String> tokens, int[] token_i, String[] error_msg, boolean parent_is_comp) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: key:" + parent_is_comp + " " + tokens.get(token_i[0]));
+		String cur_token = tokens.get(token_i[0]);
+		if(cur_token.charAt(0) == '_') {
+			NBTExpr_AST node = new NBTExpr_AST();
+			node.type = ASTType.KEY;
+			node.str = cur_token.substring(1, cur_token.length());
+			token_i[0] += 1;
+			if(eat_token(tokens, token_i, ".")) {
+				node.child0 = parse_key(tokens, token_i, error_msg, parent_is_comp);
+				if(node.child0 == null) return null;
+				return node;
+			} else if(eat_token(tokens, token_i, "[")) {
+				try {
+					//note: this is a lazy way of implementing numerical indexing: "list[5]", the proper way to do this is with a non-deterministic call to a recursive parsing function. As a consequence, multi-dimensional arrays are not index-able, so "list[5][2]" does not work.
+					node.child0 = new NBTExpr_AST();
+					node.child0.type = ASTType.INDEX;
+					node.child0.numeral = Double.parseDouble(tokens.get(token_i[0]));
+					token_i[0] += 1;
+					if(eat_token(tokens, token_i, "]")) {
+						if(eat_token(tokens, token_i, ".")) {
+							node.child0.child0 = parse_key(tokens, token_i, error_msg, parent_is_comp);
+							if(node.child0.child0 == null) return null;
+							return node;
+						} else {
+							return node;
+						}
+					} else {
+						error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "closing \"]\"");
+						return null;
+					}
+				} catch (Exception e) {
+					if(parent_is_comp) {//block parsing a FIND expr when parent is a comp operator
+						error_msg[0] = msg_unexpected(cur_token, "a numeral");
+						return null;
+					} else {
+						node.child0 = new NBTExpr_AST();
+						node.child0.type = ASTType.FIND;
+						node.child0.child0 = parse_and(tokens, token_i, error_msg);
+						if(node.child0.child0 == null) return null;
+						if(eat_token(tokens, token_i, "]")) {
+							return node;
+						} else {
+							error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "closing \"]\"");
+							return null;
+						}
+					}
+				}
+			} else {
+				return node;
+			}
+		} else {
+			error_msg[0] = msg_unexpected(cur_token, "an nbt key");
+			return null;
+		}
+	}
+
+	NBTExpr_AST parse_comp(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: comp " + tokens.get(token_i[0]));
+		NBTExpr_AST node_child = parse_key(tokens, token_i, error_msg, true);
+		if(node_child == null) return null;
+		if(eat_token(tokens, token_i, "<")) {
+			NBTExpr_AST node = new NBTExpr_AST();
+			node.type = ASTType.LT;
+			node.child0 = node_child;
+			try {
+				node.numeral = Double.parseDouble(tokens.get(token_i[0]));
+				token_i[0] += 1;
+				return node;
+			} catch (Exception e) {
+				error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "numeral");
+				return null;
+			}
+		} else if(eat_token(tokens, token_i, ">")) {
+			NBTExpr_AST node = new NBTExpr_AST();
+			node.type = ASTType.GT;
+			node.child0 = node_child;
+			try {
+				node.numeral = Double.parseDouble(tokens.get(token_i[0]));
+				token_i[0] += 1;
+				return node;
+			} catch (Exception e) {
+				error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "numeral");
+				return null;
+			}
+		} else if(eat_token(tokens, token_i, "=")) {
+			NBTExpr_AST node = new NBTExpr_AST();
+			node.child0 = node_child;
+			String cur_token = tokens.get(token_i[0]);
+			char ch = cur_token.charAt(0);
+			if(ch == '_') {
+				token_i[0] += 1;
+				node.type = ASTType.STREQ;
+				node.str = cur_token.substring(1, cur_token.length());
+				return node;
+			} else {
+				node.type = ASTType.EQ;
+				try {
+					// MagicSpells.sendDebugMessage("NBTExpr debug: comp2 " + token_i[0] + " " + cur_token);
+					token_i[0] += 1;
+					node.numeral = Double.parseDouble(cur_token);
+					return node;
+				} catch (Exception e) {
+					error_msg[0] = msg_unexpected(cur_token, "numeral or string");
+					return null;
+				}
+			}
+		} else {
+			error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "comparison operator");
+			return null;
+		}
+	}
+
+	NBTExpr_AST parse_nbt_operation(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: op " + tokens.get(token_i[0]));
+		//we need to non-deterministically test for a comparison operation separately from a EXISTS operation to prevent a FIND node from appearing as a child to a comparison operation
+		//FIND is only interprettable as an nbt indexing operation when it is a child to an EXISTS operation
+		int pre_token_i = token_i[0];
+		String[] nd_error_msg = {""};
+		NBTExpr_AST node = parse_comp(tokens, token_i, nd_error_msg);
+		if(node == null) {
+			//restore parser state to before non-det check
+			token_i[0] = pre_token_i;
+			// MagicSpells.sendDebugMessage("NBTExpr debug: op2 " + tokens.get(token_i[0]));
+			node = new NBTExpr_AST();
+			node.type = ASTType.EXISTS;
+			node.child0 = parse_key(tokens, token_i, error_msg, false);
+			if(node.child0 == null) {
+				error_msg[0] = nd_error_msg[0];//the parse_comp error message is more likely to be informative, the proper way to decide which error message gets displayed is to build some kind of error priority system
+				return null;
+			}
+			return node;
+		} else {
+			return node;
+		}
+	}
+
+	NBTExpr_AST parse_not(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: not " + tokens.get(token_i[0]));
+		if(eat_token(tokens, token_i, "!")) {
+			NBTExpr_AST node = new NBTExpr_AST();
+			node.type = ASTType.NOT;
+			node.child0 = parse_not(tokens, token_i, error_msg);
+			if(node.child0 == null) return null;
+			return node;
+		} else if(eat_token(tokens, token_i, "(")) {
+			NBTExpr_AST node = parse_and(tokens, token_i, error_msg);
+			if(node == null) return null;
+			// MagicSpells.sendDebugMessage("NBTExpr debug: not2 " + tokens.get(token_i[0]));
+			if(eat_token(tokens, token_i, ")")) {
+				return node;
+			} else {
+				error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "closing \")\"");
+				return null;
+			}
+		} else {
+			return parse_nbt_operation(tokens, token_i, error_msg);
+		}
+	}
+	NBTExpr_AST parse_or(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: or " + tokens.get(token_i[0]));
+		String[] op_strings = {"|"};
+		ASTType[] op_types   = {ASTType.OR};
+		return parse_left_binops(tokens, token_i, error_msg, op_strings, op_types, new ParseFunc() {
+			public NBTExpr_AST func(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+				return parse_not(tokens, token_i, error_msg);
+			}
+		});
+	}
+	NBTExpr_AST parse_and(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+		// MagicSpells.sendDebugMessage("NBTExpr debug: and " + tokens.get(token_i[0]));
+		String[] op_strings = {"&"};
+		ASTType[] op_types   = {ASTType.AND};
+		return parse_left_binops(tokens, token_i, error_msg, op_strings, op_types, new ParseFunc() {
+			public NBTExpr_AST func(ArrayList<String> tokens, int[] token_i, String[] error_msg) {
+				return parse_or(tokens, token_i, error_msg);
+			}
+		});
+	}
+
+	NBTExpr_AST parse_expr(ArrayList<String> tokens, String[] error_msg) {
+		int[] token_i = {0};
+		NBTExpr_AST root = parse_and(tokens, token_i, error_msg);
+		if(root == null) {
+			return null;
+		} else {
+			if(eat_token(tokens, token_i, "\n")) {
+				return root;
+			} else {
+				error_msg[0] = msg_unexpected(tokens.get(token_i[0]), "end of expression");
+				return null;
+			}
+		}
+	}
+
+
+
+
+
+	public boolean eval_nbt_index(NBTExpr_AST root, NBTTagList taglist, NBTExpr_AST operation) {
+		int i = (int)Math.floor(root.numeral);
+		if(root.child0 != null) {
+			return eval_nbt_key(root.child0, taglist.get(i), operation);
+		} else if (operation.type == ASTType.EXISTS) {
+			return 0 <= i && i < taglist.size();
+		} else if (operation.type == ASTType.GT) {
+			double test = taglist.c(i);
+			return test > operation.numeral;
+		} else if (operation.type == ASTType.LT) {
+			double test = taglist.c(i);
+			return test < operation.numeral;
+		} else if (operation.type == ASTType.EQ) {
+			double test = taglist.c(i);
+			return Math.abs(test - operation.numeral) < .00001;
+		} else if (operation.type == ASTType.STREQ) {
+			String test = taglist.getString(i);
+			return test.equals(operation.str);
+		} else {
+			MagicSpells.error("NBTExpr error: Invalid operation");
+			return false;
+		}
+	}
+
+	public boolean eval_nbt_key(NBTExpr_AST root, NBTTagCompound compound, NBTExpr_AST operation) {
+		if(root.child0 != null) {
+			if(root.child0.type == ASTType.INDEX) {
+				NBTTagList taglist = compound.getList(root.str, 0);
+				for(int i = 1; i < 12; i += 1) {//I hate this nbt interface
+					taglist = compound.getList(root.str, i);
+					if(taglist.size() > 0) break;
+				}
+				return eval_nbt_index(root.child0, taglist, operation);
+			} else if(root.child0.type == ASTType.FIND) {
+				if(operation.type == ASTType.EXISTS) {
+					NBTTagList taglist = compound.getList(root.str, 10);
+					for(int i = 0; i < taglist.size(); i += 1) {
+						NBTTagCompound cur_compound = taglist.get(i);
+						if(eval_expr(root.child0.child0, cur_compound)) {
+							return true;
+						}
+					}
+					return false;
+				} else {
+					//should not be possible
+					MagicSpells.error("NBTExpr error: Malformed syntax tree, expected operation type EXISTS");
+					return false;
+				}
+			} else {
+				return eval_nbt_key(root.child0, compound.getCompound(root.str), operation);
+			}
+		} else if (operation.type == ASTType.EXISTS) {
+			return compound.hasKey(root.str);
+		} else if (operation.type == ASTType.GT) {
+			double test = compound.getDouble(root.str);
+			return test > operation.numeral;
+		} else if (operation.type == ASTType.LT) {
+			double test = compound.getDouble(root.str);
+			return test < operation.numeral;
+		} else if (operation.type == ASTType.EQ) {
+			double test = compound.getDouble(root.str);
+			return Math.abs(test - operation.numeral) < .00001;
+		} else if (operation.type == ASTType.STREQ) {
+			String test = compound.getString(root.str);
+			return test.equals(operation.str);
+		} else {
+			//should not be possible
+			MagicSpells.error("NBTExpr error: Invalid operation");
+			return false;
+		}
+	}
+	public boolean eval_expr(NBTExpr_AST root, NBTTagCompound compound) {
+		if (root.type == ASTType.EXISTS || root.type == ASTType.GT || root.type == ASTType.LT || root.type == ASTType.EQ || root.type == ASTType.STREQ) {
+			if(root.child0.type == ASTType.KEY) {
+				return eval_nbt_key(root.child0, compound, root);
+			} else {
+				//should not be possible
+				MagicSpells.error("NBTExpr error: Malformed syntax tree, expected child type KEY");
+				return false;
+			}
+		} else if (root.type == ASTType.AND) {
+			return eval_expr(root.child0, compound) && eval_expr(root.child1, compound);
+		} else if (root.type == ASTType.OR) {
+			return eval_expr(root.child0, compound) || eval_expr(root.child1, compound);
+		} else if (root.type == ASTType.NOT) {
+			return !(eval_expr(root.child0, compound));
+		} else {
+			MagicSpells.error("NBTExpr error: Malformed syntax tree, expected operation type");
+			//This error should not be possible given a syntax tree produced by lexing and parsing
+			//The only remaining ast types; KEY, INDEX, FIND, require a parent with a nbt operation type to be interpretted
+			//If anyone wants to run eval_expr on a syntax tree not produced by the function parse_expr(), be careful when constructing the tree or else errors like this may be produced.
+			return false;
+		}
+	}
+
+
+
+	@Override
+	public boolean setVar(String var) {
+		String[] error_msg = {""};
+		ArrayList<String> tokens = lex(var, error_msg);
+		// MagicSpells.sendDebugMessage("NBTExpr debug: " + tokens);
+		if(tokens == null) {
+			MagicSpells.error(error_msg[0]);
+			return false;
+		}
+		config_ast = parse_expr(tokens, error_msg);
+		if(config_ast == null) {
+			MagicSpells.error(error_msg[0]);
+			return false;
+		} else {
+			return true;
+		}
+	}
+
+	@Override
+	public boolean check(Player player) {
+		return check((LivingEntity)player);
+	}
+
+	public boolean check(LivingEntity target) {
+		NBTTagCompound compound = new NBTTagCompound();
+
+		EntityLiving el = ((CraftLivingEntity)target).getHandle();
+
+    	el.b(compound);
+
+		return eval_expr(config_ast, compound);
+	}
+
+	@Override
+	public boolean check(Player player, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(Player player, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTGreaterThan.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTGreaterThan.java
@@ -30,7 +30,11 @@ public class NBTGreaterThan extends Condition {
 	public boolean setVar(String var) {
 		try {
 			String[] data = var.split(":");
-			key = data[0].split("-");
+			key = data[0].split(".");
+			if(key.length == 0) {
+				String[] t = {data[0]};
+				key = t;
+			}
 			val = Double.parseDouble(data[1]);
 			return true;
 		} catch (NumberFormatException e) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTLessThan.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTLessThan.java
@@ -30,7 +30,11 @@ public class NBTLessThan extends Condition {
 	public boolean setVar(String var) {
 		try {
 			String[] data = var.split(":");
-			key = data[0].split("-");
+			key = data[0].split(".");
+			if(key.length == 0) {
+				String[] t = {data[0]};
+				key = t;
+			}
 			val = Double.parseDouble(data[1]);
 			return true;
 		} catch (NumberFormatException e) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTMatches.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NBTMatches.java
@@ -30,7 +30,11 @@ public class NBTMatches extends Condition {
 	public boolean setVar(String var) {
 		try {
 			String[] data = var.split(":");
-			key = data[0].split("-");
+			key = data[0].split(".");
+			if(key.length == 0) {
+				String[] t = {data[0]};
+				key = t;
+			}
 			val = data[1];
 			return true;
 		} catch (NumberFormatException e) {


### PR DESCRIPTION
Added nbtexpr, a powerful target-modifer I explained in the sneakyrp discord.
The previous nbt target-modifers were modified to use . instead of - for nbt keys, to be in line with the nbtexpr syntax. Unfortunately, this syntax change is not backwards compatible, but it's an early and small syntax change.

Also my text editor nuked the trailing whitespace in MagicSpells.java. Probably for the best.