### PR TITLE
Mami

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -574,11 +574,12 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	protected String rechargeSound;
 
 	private List<String> modifierStrings;
-
 	private List<String> targetModifierStrings;
+	private List<String> locationModifierStrings;
 
 	protected ModifierSet modifiers;
 	protected ModifierSet targetModifiers;
+	protected ModifierSet locationModifiers;
 
 	protected List<String> prerequisites;
 
@@ -854,6 +855,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		// Modifiers
 		this.modifierStrings = config.getStringList(section + '.' + spellName + ".modifiers", null);
 		this.targetModifierStrings = config.getStringList(section + '.' + spellName + ".target-modifiers", null);
+		this.locationModifierStrings = config.getStringList(section + '.' + spellName + ".target-modifiers", null);
 
 		// Hierarchy options
 		this.prerequisites = config.getStringList(section + '.' + spellName + ".prerequisites", null);
@@ -1049,6 +1051,11 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			debug(2, "Adding target modifiers to " + this.internalName + " spell");
 			this.targetModifiers = new ModifierSet(this.targetModifierStrings);
 			this.targetModifierStrings = null;
+		}
+		if (this.locationModifierStrings != null && !this.locationModifierStrings.isEmpty()) {
+			debug(2, "Adding location modifiers to " + this.internalName + " spell");
+			this.locationModifiers = new ModifierSet(this.locationModifierStrings);
+			this.locationModifierStrings = null;
 		}
 
 		// Process shared cooldowns
@@ -2243,6 +2250,9 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	public ModifierSet getTargetModifiers() {
 		return this.targetModifiers;
+	}
+	public ModifierSet getLocationModifiers() {
+		return this.locationModifiers;
 	}
 
 	public String getStrModifierFailed() {

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -855,7 +855,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		// Modifiers
 		this.modifierStrings = config.getStringList(section + '.' + spellName + ".modifiers", null);
 		this.targetModifierStrings = config.getStringList(section + '.' + spellName + ".target-modifiers", null);
-		this.locationModifierStrings = config.getStringList(section + '.' + spellName + ".target-modifiers", null);
+		this.locationModifierStrings = config.getStringList(section + '.' + spellName + ".location-modifiers", null);
 
 		// Hierarchy options
 		this.prerequisites = config.getStringList(section + '.' + spellName + ".prerequisites", null);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
@@ -134,6 +134,7 @@ public abstract class Condition {
 		conditions.put("testforblock", TestForBlockCondition.class);
 		conditions.put("richerthan", RicherThanCondition.class);
 		conditions.put("lookingatblock", LookingAtBlockCondition.class);
+		conditions.put("lookingatblockdebug", LookingAtBlockDebugCondition.class);
 		conditions.put("oncooldown", OnCooldownCondition.class);
 		conditions.put("hasmark", HasMarkCondition.class);
 		conditions.put("playercountabove", PlayerCountAboveCondition.class);
@@ -188,6 +189,5 @@ public abstract class Condition {
 		conditions.put("nbtdebug", NBTDebug.class);
 		conditions.put("nbtmatches", NBTMatches.class);
 		conditions.put("nbtexpr", NBTExpr.class);
-		conditions.put("nbtexpression", NBTExpr.class);
 	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/Modifier.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/Modifier.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.castmodifiers;
 import com.nisovin.magicspells.util.RegexUtil;
 import org.bukkit.entity.Player;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.DebugHandler;
 import com.nisovin.magicspells.events.MagicSpellsGenericPlayerEvent;
 import com.nisovin.magicspells.events.ManaChangeEvent;
@@ -45,11 +46,11 @@ public class Modifier implements IModifier {
 		if (m.condition == null) return null;
 
 		// Get type and vars
-		m.type = getTypeByName(data[1]);
+		m.type = ModifierType.getModifierTypeByName(data[1]);
 		if (m.type == null && data.length > 2) {
 			boolean varok = m.condition.setVar(data[1]);
 			if (!varok) return null;
-			m.type = getTypeByName(data[2]);
+			m.type = ModifierType.getModifierTypeByName(data[2]);
 			if (data.length > 3) m.modifierVar = data[3];
 		} else if (data.length > 2) {
 			m.modifierVar = data[2];
@@ -156,10 +157,6 @@ public class Modifier implements IModifier {
 		if (!check && type == ModifierType.REQUIRED) return false;
 		if (check && type == ModifierType.DENIED) return false;
 		return true;
-	}
-
-	private static ModifierType getTypeByName(String name) {
-		return ModifierType.getModifierTypeByName(name);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -19,9 +19,9 @@ import com.nisovin.magicspells.util.VariableMod;
 import com.nisovin.magicspells.util.VariableMod.VariableOwner;
 
 public enum ModifierType {
-	
+
 	REQUIRED(false, false, false, false, "required", "require") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (!check) event.setCancelled(true);
@@ -51,11 +51,11 @@ public enum ModifierType {
 			if (!check) event.setCancelled(true);
 			return check;
 		}
-		
+
 	},
-	
+
 	DENIED(false, false, false, false, "denied", "deny") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.setCancelled(true);
@@ -85,11 +85,11 @@ public enum ModifierType {
 			if (check) event.setCancelled(true);
 			return !check;
 		}
-		
+
 	},
-	
+
 	POWER(false, true, false, false, "power", "empower", "multiply") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.increasePower(modifierVarFloat);
@@ -123,11 +123,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return true;
 		}
-		
+
 	},
-	
+
 	ADD_POWER(false, true, false, false, "addpower", "add") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.setPower(event.getPower() + modifierVarFloat);
@@ -160,11 +160,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return true;
 		}
-		
+
 	},
-	
+
 	COOLDOWN(false, true, false, false, "cooldown") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.setCooldown(modifierVarFloat);
@@ -190,11 +190,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return true;
 		}
-		
+
 	},
-	
+
 	REAGENTS(false, true, false, false, "reagents") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.setReagents(event.getReagents().multiply(modifierVarFloat));
@@ -220,11 +220,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return true;
 		}
-		
+
 	},
-	
+
 	CAST_TIME(false, false, true, false, "casttime") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) event.setCastTime(modifierVarInt);
@@ -250,11 +250,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return true;
 		}
-		
+
 	},
-	
+
 	STOP(false, false, false, false, "stop") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return !check;
@@ -279,11 +279,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return !check;
 		}
-		
+
 	},
-	
+
 	CONTINUE(false, false, false, false, "continue") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return check;
@@ -308,11 +308,11 @@ public enum ModifierType {
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			return check;
 		}
-		
+
 	},
-	
+
 	CAST(true, false, false, false, "cast") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -361,11 +361,11 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 	},
-	
+
 	CAST_INSTEAD(true, false, false, false, "castinstead") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -394,10 +394,13 @@ public enum ModifierType {
 				if (spell != null) {
 					if (spell instanceof TargetedEntitySpell) {
 						((TargetedEntitySpell)spell).castAtEntity(event.getCaster(), event.getTarget(), 1F);
+					} else if (spell instanceof TargetedLocationSpell) {
+						((TargetedLocationSpell)spell).castAtLocation(event.getCaster(), event.getTarget().getLocation(), 1F);
 					} else {
 						spell.castSpell(event.getCaster(), SpellCastState.NORMAL, 1F, null);
 					}
 				}
+				event.setCancelled(true);
 			}
 			return true;
 		}
@@ -406,10 +409,14 @@ public enum ModifierType {
 		public boolean apply(SpellTargetLocationEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
 				Spell spell = MagicSpells.getSpellByInternalName(modifierVar);
-				if (spell instanceof TargetedLocationSpell) {
-					((TargetedLocationSpell)spell).castAtLocation(event.getCaster(), event.getTargetLocation(), 1F);
-					event.setCancelled(true);
+				if (spell != null) {
+					if (spell instanceof TargetedLocationSpell) {
+						((TargetedLocationSpell)spell).castAtLocation(event.getCaster(), event.getTargetLocation(), 1F);
+					} else {
+						spell.castSpell(event.getCaster(), SpellCastState.NORMAL, 1F, null);
+					}
 				}
+				event.setCancelled(true);
 			}
 			return true;
 		}
@@ -419,27 +426,28 @@ public enum ModifierType {
 			if (check) {
 				Spell spell = MagicSpells.getSpellByInternalName(modifierVar);
 				if (spell != null) spell.cast(event.getPlayer(), 1, null);
+				event.setCancelled(true);
 			}
 			return true;
 		}
-		
+
 	},
-	
-	
+
+
 	VARIABLE_MODIFY(false, false, false, true, "variable") {
-		
+
 		class CustomData {
-			
+
 			public VariableOwner modifiedVariableOwner;
 			public String modifiedVariableName;
 			public VariableMod mod;
-			
+
 			CustomData() {
-				
+
 			}
-			
+
 		}
-		
+
 		private void modifyVariable(String variableName, VariableOwner modifiedVariableOwner, Player caster, Player targetPlayer, VariableMod.Operation op, double amount) {
 			Player varToModifiyOwnerPlayer = modifiedVariableOwner == VariableOwner.CASTER ? caster: targetPlayer;
 			switch (op) {
@@ -457,12 +465,12 @@ public enum ModifierType {
 				break;
 			}
 		}
-		
+
 		boolean isDataOk(CustomData data, Player caster, Player target) {
 			boolean needsTarget = data.modifiedVariableOwner == VariableOwner.TARGET || (data.mod.getVariableOwner() == VariableOwner.TARGET && !data.mod.isConstantValue());
 			return !needsTarget || target != null;
 		}
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -523,7 +531,7 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public Object buildCustomActionData(String text) {
 			//input format
@@ -544,7 +552,7 @@ public enum ModifierType {
 				modifiedVariableOwner = VariableOwner.CASTER;
 				modifiedVariableName = modifiedVariableData;
 			}
-			
+
 			VariableMod variableModifier = new VariableMod(splits[1]);
 			CustomData ret = new CustomData();
 			ret.mod = variableModifier;
@@ -552,22 +560,22 @@ public enum ModifierType {
 			ret.modifiedVariableOwner = modifiedVariableOwner;
 			return ret;
 		}
-		
+
 	},
-	
+
 	STRING(false, false, false, true, "string") {
-		
+
 		class CustomData {
-			
+
 			public Variable variable;
 			public String value;
-			
+
 		}
-		
+
 		private void setVariable(Player player, CustomData customData) {
 			customData.variable.parseAndSet(player, customData.value);
 		}
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -575,7 +583,7 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -583,7 +591,7 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(SpellTargetEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -591,7 +599,7 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(SpellTargetLocationEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -599,7 +607,7 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
 			if (check) {
@@ -607,33 +615,33 @@ public enum ModifierType {
 			}
 			return true;
 		}
-		
+
 		@Override
 		public Object buildCustomActionData(String text) {
 			if (text == null || text.trim().isEmpty() || !text.contains(" ")) throw new IllegalArgumentException("action \"string\" requires arguments.");
-			
+
 			String[] splits = text.split(" ", 2);
 			Variable variable = MagicSpells.getVariableManager().getVariable(splits[0]);
 			if (variable == null) throw new IllegalArgumentException(splits[0] + " is not a defined variable!");
-			
+
 			CustomData ret = new CustomData();
 			ret.variable = variable;
 			ret.value = splits[1];
 			return ret;
 		}
-		
+
 	}
-	
+
 	;
-	
+
 	private String[] keys;
 	private static boolean initialized = false;
-	
+
 	private boolean usesCustomData = false;
 	private boolean usesModifierVar = false;
 	private boolean usesModifierVarFloat = false;
 	private boolean usesModifierVarInt = false;
-	
+
 	ModifierType(boolean usesModVarString, boolean usesModVarFloat, boolean usesModVarInt, boolean usesCustomData, String... keys) {
 		this.keys = keys;
 		this.usesCustomData = usesCustomData;
@@ -641,35 +649,35 @@ public enum ModifierType {
 		this.usesModifierVarFloat = usesModVarFloat;
 		this.usesModifierVarInt = usesModVarInt;
 	}
-	
+
 	public boolean usesCustomData() {
 		return usesCustomData;
 	}
-	
+
 	public boolean usesModifierString() {
 		return usesModifierVar;
 	}
-	
+
 	public boolean usesModifierFloat() {
 		return usesModifierVarFloat;
 	}
-	
+
 	public boolean usesModifierInt() {
 		return usesModifierVarInt;
 	}
-	
+
 	public abstract boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData);
 	public abstract boolean apply(ManaChangeEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData);
 	public abstract boolean apply(SpellTargetEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData);
 	public abstract boolean apply(SpellTargetLocationEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData);
 	public abstract boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData);
-	
+
 	public Object buildCustomActionData(String text) {
 		return null;
 	}
-	
+
 	static HashMap<String, ModifierType> nameMap;
-	
+
 	static void initialize() {
 		nameMap = new HashMap<>();
 		for (ModifierType type: ModifierType.values()) {
@@ -679,10 +687,10 @@ public enum ModifierType {
 		}
 		initialized = true;
 	}
-	
+
 	public static ModifierType getModifierTypeByName(String name) {
 		if (!initialized) initialize();
 		return nameMap.get(name.toLowerCase());
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/TargetListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/TargetListener.java
@@ -7,62 +7,63 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class TargetListener implements Listener {
-	
+
 	private List<IModifier> preModifierHooks;
 	private List<IModifier> postModifierHooks;
-	
+
 	public TargetListener() {
 		preModifierHooks = new CopyOnWriteArrayList<>();
 		postModifierHooks = new CopyOnWriteArrayList<>();
 	}
-	
+
 	@EventHandler(priority=EventPriority.LOW, ignoreCancelled=true)
 	public void onSpellTarget(SpellTargetEvent event) {
 		for (IModifier premod: preModifierHooks) {
 			if (!premod.apply(event)) return;
 		}
-		
+
 		ModifierSet m = event.getSpell().getTargetModifiers();
 		if (m != null) m.apply(event);
-		
+
 		for (IModifier postMod: postModifierHooks) {
 			if (!postMod.apply(event)) return;
 		}
 	}
-	
+
 	@EventHandler(priority=EventPriority.LOW, ignoreCancelled=true)
 	public void onSpellTarget(SpellTargetLocationEvent event) {
 		for (IModifier premod: preModifierHooks) {
 			if (!premod.apply(event)) return;
 		}
-		
-		ModifierSet m = event.getSpell().getTargetModifiers();
+
+		ModifierSet m = event.getSpell().getLocationModifiers();
 		if (m != null) m.apply(event);
-		
+
 		for (IModifier postMod: postModifierHooks) {
 			if (!postMod.apply(event)) return;
 		}
 	}
-	
+
 	public void addPreModifierHook(IModifier hook) {
 		if (hook == null) return;
 		preModifierHooks.add(hook);
 	}
-	
+
 	public void addPostModifierHook(IModifier hook) {
 		if (hook == null) return;
 		postModifierHooks.add(hook);
 	}
-	
+
 	public void unload() {
 		preModifierHooks.clear();
 		preModifierHooks = null;
 		postModifierHooks.clear();
 		postModifierHooks = null;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/InBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/InBlockCondition.java
@@ -38,17 +38,17 @@ public class InBlockCondition extends Condition {
 		mat = MagicSpells.getItemNameResolver().resolveBlock(var);
 		return mat != null;
 	}
-	
+
 	@Override
 	public boolean check(Player player) {
 		return check(player, player);
 	}
-	
+
 	@Override
 	public boolean check(Player player, LivingEntity target) {
 		Block block = target.getLocation().getBlock();
 		if (mat != null) return mat.equals(block);
-		
+
 		if (types.contains(block.getType())) {
 			for (MagicMaterial m : mats) {
 				if (m.equals(block)) return true;
@@ -56,7 +56,7 @@ public class InBlockCondition extends Condition {
 		}
 		return false;
 	}
-	
+
 	@Override
 	public boolean check(Player player, Location location) {
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockCondition.java
@@ -14,7 +14,7 @@ public class LookingAtBlockCondition extends Condition {
 
 	MagicMaterial blockType;
 	int dist = 4;
-	
+
 	@Override
 	public boolean setVar(String var) {
 		try {
@@ -45,5 +45,5 @@ public class LookingAtBlockCondition extends Condition {
 	public boolean check(Player player, Location location) {
 		return check(player);
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockDebugCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockDebugCondition.java
@@ -1,0 +1,29 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.Material;
+import org.bukkit.material.MaterialData;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+import com.nisovin.magicspells.castmodifiers.conditions.LookingAtBlockCondition;
+import com.nisovin.magicspells.materials.MagicMaterial;
+import com.nisovin.magicspells.util.BlockUtils;
+
+public class LookingAtBlockDebugCondition extends LookingAtBlockCondition {
+	@Override
+	public boolean check(Player player, LivingEntity target) {
+		Block block = BlockUtils.getTargetBlock(null, target, dist);
+		MaterialData data = block.getState().getData();
+		Material type = data.getItemType();
+		if(type == Material.LOG || type == Material.SAPLING || type == Material.WOOD || type == Material.LEAVES || type == Material.WOOL) {
+			MagicSpells.sendDebugMessage("MagicSpells has a custom syntax for specifying the block data of a block of type '" + type.name().toLowerCase() + "'; Consult 'MagicItemNameResolver.java' if you are unsure of how to use this syntax");
+		} else {
+			MagicSpells.sendDebugMessage(type.name().toLowerCase() + ":" + data.getData());
+		}
+		return blockType.equals(block);
+	}
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnBlockCondition.java
@@ -43,7 +43,7 @@ public class OnBlockCondition extends Condition {
 	public boolean check(Player player) {
 		return check(player, player);
 	}
-	
+
 	@Override
 	public boolean check(Player player, LivingEntity target) {
 		Block block = target.getLocation().subtract(0, 1, 0).getBlock();
@@ -55,7 +55,7 @@ public class OnBlockCondition extends Condition {
 		}
 		return false;
 	}
-	
+
 	@Override
 	public boolean check(Player player, Location location) {
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TestForBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TestForBlockCondition.java
@@ -14,7 +14,7 @@ public class TestForBlockCondition extends Condition {
 
 	MagicLocation location;
 	MagicMaterial blockType;
-	
+
 	@Override
 	public boolean setVar(String var) {
 		try {

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
@@ -19,13 +19,13 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	private LivingEntity target;
 	private float power;
 	private boolean cancelled = false;
-	
+
 	public SpellTargetEvent(Spell spell, Player caster, LivingEntity target, float power) {
 		super(spell, caster);
 		this.target = target;
 		this.power = power;
 	}
-	
+
 	/**
 	 * Gets the living entity that is being targeted by the spell.
 	 * @return the targeted living entity
@@ -33,7 +33,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	public LivingEntity getTarget() {
 		return this.target;
 	}
-	
+
 	/**
 	 * Sets the spell's target to the provided living entity.
 	 * @param target the new target
@@ -41,7 +41,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	public void setTarget(LivingEntity target) {
 		this.target = target;
 	}
-	
+
 	/**
 	 * Gets the current power level of the spell. Spells start at a power level of 1.0.
 	 * @return the power level
@@ -49,7 +49,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	public float getPower() {
 		return this.power;
 	}
-	
+
 	/**
 	 * Sets the power level for the spell being cast.
 	 * @param power the power level
@@ -57,7 +57,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	public void setPower(float power) {
 		this.power = power;
 	}
-	
+
 	/**
 	 * Increases the power lever for the spell being cast by the given multiplier.
 	 * @param power the power level multiplier
@@ -73,7 +73,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 
 	@Override
 	public void setCancelled(boolean cancelled) {
-		this.cancelled = cancelled;		
+		this.cancelled = cancelled;
 	}
 
     @Override
@@ -84,5 +84,5 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
     public static HandlerList getHandlerList() {
         return handlers;
     }
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/materials/ItemNameResolver.java
+++ b/core/src/main/java/com/nisovin/magicspells/materials/ItemNameResolver.java
@@ -9,16 +9,16 @@ public interface ItemNameResolver {
 
 	@Deprecated
 	ItemTypeAndData resolve(String string);
-	
+
 	MagicMaterial resolveItem(String string);
-	
+
 	MagicMaterial resolveBlock(String string);
-	
+
 	class ItemTypeAndData {
-		
+
 		public int id = 0;
 		public short data = 0;
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/materials/MagicBlockMaterial.java
+++ b/core/src/main/java/com/nisovin/magicspells/materials/MagicBlockMaterial.java
@@ -9,23 +9,23 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.material.MaterialData;
 
 public class MagicBlockMaterial extends MagicMaterial {
-	
+
 	MaterialData data;
-	
+
 	public MagicBlockMaterial(MaterialData data) {
 		this.data = data;
 	}
-	
+
 	@Override
 	public Material getMaterial() {
 		return this.data.getItemType();
 	}
-	
+
 	@Override
 	public MaterialData getMaterialData() {
 		return this.data;
 	}
-	
+
 	@Override
 	public void setBlock(Block block, boolean applyPhysics) {
 		BlockState state = block.getState();
@@ -33,7 +33,7 @@ public class MagicBlockMaterial extends MagicMaterial {
 		state.setData(getMaterialData());
 		state.update(true, applyPhysics);
 	}
-	
+
 	@Override
 	public FallingBlock spawnFallingBlock(Location location) {
 		return location.getWorld().spawnFallingBlock(location, getMaterial(), getMaterialData().getData());
@@ -43,5 +43,5 @@ public class MagicBlockMaterial extends MagicMaterial {
 	public ItemStack toItemStack(int quantity) {
 		return getMaterialData().toItemStack(quantity);
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/materials/MagicItemNameResolver.java
+++ b/core/src/main/java/com/nisovin/magicspells/materials/MagicItemNameResolver.java
@@ -24,19 +24,19 @@ import com.nisovin.magicspells.DebugHandler;
 import com.nisovin.magicspells.MagicSpells;
 
 public class MagicItemNameResolver implements ItemNameResolver {
-	
+
 	private static final Pattern DIGITS = Pattern.compile("[0-9]+");
 	private static final Pattern BLOCK_BYTE_DATA_PATTERN = Pattern.compile("^[0-9]+$");
-	
+
 	Map<String, Material> materialMap = new HashMap<>();
 	Map<String, MaterialData> materialDataMap = new HashMap<>();
 	Random rand = new Random();
-	
+
 	public MagicItemNameResolver() {
 		for (Material mat : Material.values()) {
 			this.materialMap.put(mat.name().toLowerCase(), mat);
 		}
-		
+
 		File file = new File(MagicSpells.getInstance().getDataFolder(), "itemnames.yml");
 		if (!file.exists()) {
 			MagicSpells.getInstance().saveResource("itemnames.yml", false);
@@ -52,7 +52,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
-		
+
 		Map<String, Material> toAdd = new HashMap<>();
 		for (String s : this.materialMap.keySet()) {
 			if (s.contains("_")) {
@@ -61,7 +61,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 		}
 		this.materialMap.putAll(toAdd);
 	}
-	
+
 	@Override
 	public ItemTypeAndData resolve(String string) {
 		if (string == null || string.isEmpty()) return null;
@@ -91,18 +91,18 @@ public class MagicItemNameResolver implements ItemNameResolver {
 		}
 		return item;
 	}
-	
+
 	@Override
 	public MagicMaterial resolveItem(String string) {
 		if (string == null || string.isEmpty()) return null;
-		
+
 		// first check for predefined material datas
 		MaterialData matData = this.materialDataMap.get(string.toLowerCase());
 		if (matData != null) {
 			if (matData.getItemType().isBlock()) return new MagicBlockMaterial(matData);
 			return new MagicItemMaterial(matData);
 		}
-		
+
 		// split type and data
 		String stype;
 		String sdata;
@@ -118,10 +118,10 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			stype = string.toLowerCase();
 			sdata = "";
 		}
-		
+
 		Material type = this.materialMap.get(stype);
 		if (type == null) return resolveUnknown(stype, sdata);
-		
+
 		if (type.isBlock()) {
 			return new MagicBlockMaterial(resolveBlockData(type, sdata));
 		} else {
@@ -137,13 +137,13 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return new MagicItemMaterial(type, durability);
 		}
 	}
-	
+
 	@Override
 	public MagicMaterial resolveBlock(String string) {
 		if (string == null || string.isEmpty()) return null;
-		
+
 		if (string.contains("|")) return resolveRandomBlock(string);
-		
+
 		String stype;
 		String sdata;
 		if (string.contains(":")) {
@@ -154,12 +154,12 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			stype = string.toLowerCase();
 			sdata = "";
 		}
-		
+
 		Material type = this.materialMap.get(stype);
 		if (type == null) {
 			return resolveUnknown(stype, sdata);
 		}
-		
+
 		if (type.isBlock()) {
 			if (sdata.equals("*")) {
 				return new MagicBlockAnyDataMaterial(new MaterialData(type));
@@ -170,7 +170,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return null;
 		}
 	}
-	
+
 	private MagicMaterial resolveRandomBlock(String string) {
 		List<MagicMaterial> materials = new ArrayList<>();
 		String[] strings = string.split("\\|");
@@ -181,7 +181,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 		}
 		return new MagicBlockRandomMaterial(materials.toArray(new MagicMaterial[materials.size()]));
 	}
-	
+
 	private MaterialData resolveBlockData(Material type, String sdata) {
 		if (type == Material.LOG || type == Material.SAPLING || type == Material.WOOD) {
 			return getTree(sdata);
@@ -195,7 +195,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return new MaterialData(type);
 		}
 	}
-	
+
 	private MaterialData resolveItemData(Material type, String sdata) {
 		if (type == Material.INK_SACK) {
 			return getDye(sdata);
@@ -203,7 +203,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return null;
 		}
 	}
-	
+
 	private MagicMaterial resolveUnknown(String stype, String sdata) {
 		try {
 			int type = Integer.parseInt(stype);
@@ -218,17 +218,17 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return null;
 		}
 	}
-	
+
 	private Dye getDye(String data) {
 		Dye dye = new Dye();
 		dye.setColor(getDyeColor(data));
 		return dye;
 	}
-	
+
 	private Wool getWool(String data) {
 		return new Wool(getDyeColor(data));
 	}
-	
+
 	private DyeColor getDyeColor(String data) {
 		if (data != null && data.equalsIgnoreCase("random")) {
 			return DyeColor.values()[rand.nextInt(DyeColor.values().length)];
@@ -246,7 +246,7 @@ public class MagicItemNameResolver implements ItemNameResolver {
 			return color;
 		}
 	}
-	
+
 	/*
 	 * Data format
 	 * species direction
@@ -282,11 +282,11 @@ public class MagicItemNameResolver implements ItemNameResolver {
 		}
 		return new Tree(species, dir);
 	}
-	
+
 	private Leaves getLeaves(String data) {
 		return new Leaves(getTreeSpecies(data));
 	}
-	
+
 	// Data can be
 	// birch, jungle, redwood, random
 	private TreeSpecies getTreeSpecies(String data) {

--- a/core/src/main/java/com/nisovin/magicspells/materials/MagicMaterial.java
+++ b/core/src/main/java/com/nisovin/magicspells/materials/MagicMaterial.java
@@ -10,34 +10,34 @@ import org.bukkit.material.MaterialData;
 import java.util.Objects;
 
 public abstract class MagicMaterial {
-	
+
 	public abstract Material getMaterial();
-	
+
 	public abstract MaterialData getMaterialData();
-	
+
 	public final void setBlock(Block block) {
 		setBlock(block, true);
 	}
-	
+
 	public void setBlock(Block block, boolean applyPhysics) { /* NO OP */}
-	
+
 	public FallingBlock spawnFallingBlock(Location location) { return null; }
-	
+
 	public final ItemStack toItemStack() {
 		return toItemStack(1);
 	}
-	
+
 	public abstract ItemStack toItemStack(int quantity);
-	
+
 	public final boolean equals(Block block) {
 		return equals(block.getState().getData());
 	}
-	
+
 	public boolean equals(MaterialData matData) {
 		MaterialData d = getMaterialData();
 		return Objects.equals(d, matData);
 	}
-	
+
 	public boolean equals(ItemStack itemStack) {
 		MaterialData d = getMaterialData();
 		if (d != null) {
@@ -47,7 +47,7 @@ public abstract class MagicMaterial {
 			return false;
 		}
 	}
-	
+
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof MagicMaterial) {
@@ -56,21 +56,21 @@ public abstract class MagicMaterial {
 		}
 		return false;
 	}
-	
+
 	@Override
 	public int hashCode() {
 		return getMaterial().hashCode();
 	}
-	
+
 	public static MagicMaterial fromItemStack(ItemStack item) {
 		if (item.getType().isBlock()) {
 			return new MagicBlockMaterial(item.getData());
 		}
 		return new MagicItemMaterial(item.getData());
 	}
-	
+
 	public static MagicMaterial fromBlock(Block block) {
 		return new MagicBlockMaterial(block.getState().getData());
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/ArrowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/ArrowSpell.java
@@ -31,6 +31,9 @@ import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.HandHandler;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.SpellReagents;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetEvent;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 /**
  * ArrowSpell<br>
@@ -130,46 +133,46 @@ import com.nisovin.magicspells.util.SpellReagents;
 public class ArrowSpell extends Spell {
 
 	private static ArrowSpellHandler handler;
-	
+
 	String bowName;
-	
+
 	String spellNameOnHitEntity;
-	
+
 	String spellNameOnHitGround;
-	
+
 	Subspell spellOnHitEntity;
 	Subspell spellOnHitGround;
-	
+
 	boolean useBowForce;
-	
+
 	private static final String METADATA_KEY = "MSArrowSpell";
-	
+
 	public ArrowSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.bowName = ChatColor.translateAlternateColorCodes('&', getConfigString("bow-name", null));
 		this.spellNameOnHitEntity = getConfigString("spell-on-hit-entity", null);
 		this.spellNameOnHitGround = getConfigString("spell-on-hit-ground", null);
 		this.useBowForce = getConfigBoolean("use-bow-force", true);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
-		
+
 		if (this.spellNameOnHitEntity != null && !this.spellNameOnHitEntity.isEmpty()) {
 			Subspell spell = new Subspell(this.spellNameOnHitEntity);
-			if (spell.process() && spell.isTargetedEntitySpell()) this.spellOnHitEntity = spell;
+			if (spell.process() && spell.canTargetEntity()) this.spellOnHitEntity = spell;
 		}
 		if (this.spellNameOnHitGround != null && !this.spellNameOnHitGround.isEmpty()) {
 			Subspell spell = new Subspell(this.spellNameOnHitGround);
 			if (spell.process() && spell.isTargetedLocationSpell()) this.spellOnHitGround = spell;
 		}
-		
+
 		if (handler == null) handler = new ArrowSpellHandler();
 		handler.registerSpell(this);
 	}
-	
+
 	@Override
 	public void turnOff() {
 		super.turnOff();
@@ -192,19 +195,19 @@ public class ArrowSpell extends Spell {
 	public boolean canCastByCommand() {
 		return false;
 	}
-	
+
 	class ArrowSpellHandler implements Listener {
-		
+
 		Map<String, ArrowSpell> spells = new HashMap<>();
-		
+
 		public ArrowSpellHandler() {
 			registerEvents(this);
 		}
-		
+
 		public void registerSpell(ArrowSpell spell) {
 			this.spells.put(spell.bowName, spell);
 		}
-		
+
 		@EventHandler
 		public void onArrowLaunch(EntityShootBowEvent event) {
 			if (event.getEntity().getType() != EntityType.PLAYER) return;
@@ -297,27 +300,27 @@ public class ArrowSpell extends Spell {
 			arrow.remove();
 			arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
 		}
-		
+
 		public void turnOff() {
 			unregisterEvents(this);
 			this.spells.clear();
 		}
-		
+
 	}
-	
+
 	class ArrowSpellData {
-		
+
 		ArrowSpell spell;
 		boolean casted = false;
 		float power = 1.0F;
 		SpellReagents arrowSpellDataReagents;
-		
+
 		public ArrowSpellData(ArrowSpell spell, float power, SpellReagents reagents) {
 			this.spell = spell;
 			this.power = power;
 			this.arrowSpellDataReagents = reagents;
 		}
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -235,27 +235,27 @@ import com.nisovin.magicspells.util.TargetInfo;
  * </table>
  */
 public abstract class BuffSpell extends TargetedSpell implements TargetedEntitySpell {
-	
+
 	BuffSpell thisSpell;
-	
+
 	protected boolean targeted;
-	
+
 	protected boolean toggle;
-	
+
 	protected int healthCost = 0;
 	protected int manaCost = 0;
 	protected int hungerCost = 0;
 	protected int experienceCost = 0;
 	protected int levelsCost = 0;
-	
+
 	protected SpellReagents reagents;
-	
+
 	protected int useCostInterval;
-	
+
 	protected int numUses;
-	
+
 	protected float duration;
-	
+
 	protected boolean powerAffectsDuration;
 	protected boolean cancelOnGiveDamage;
 	protected boolean cancelOnTakeDamage;
@@ -267,21 +267,21 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected String strFade;
 	private boolean castWithItem;
 	private boolean castByCommand;
-	
+
 	private HashMap<String,Integer> useCounter;
 	private HashMap<String,Long> durationEndTime;
-	
+
 	private String spellOnUseIncrementName = null;
 	private Spell spellOnUseIncrement = null;
-	
+
 	private String spellOnCostName = null;
 	private Spell spellOnCost = null;
-	
-	
+
+
 	public BuffSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 		this.thisSpell = this;
-		
+
 		this.targeted = getConfigBoolean("targeted", false);
 		this.toggle = getConfigBoolean("toggle", true);
 		this.reagents = getConfigReagents("use-cost");
@@ -304,23 +304,23 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (this.cancelOnChangeWorld) registerEvents(new ChangeWorldListener());
 		if (this.cancelOnSpellCast) registerEvents(new SpellCastListener());
 		if (this.cancelOnLogout) registerEvents(new QuitListener());
-		
+
 		this.strFade = getConfigString("str-fade", "");
-		
+
 		if (this.numUses > 0 || (this.reagents != null && this.useCostInterval > 0)) {
 			this.useCounter = new HashMap<>();
 		}
 		if (this.duration > 0) this.durationEndTime = new HashMap<>();
-		
+
 		this.castWithItem = getConfigBoolean("can-cast-with-item", true);
 		this.castByCommand = getConfigBoolean("can-cast-by-command", true);
 	}
-	
+
 	@Override
 	public void initialize() {
 		// Super
 		super.initialize();
-		
+
 		// Check spell on use increment
 		if (this.spellOnUseIncrementName != null) {
 			this.spellOnUseIncrement = MagicSpells.getSpellByInternalName(this.spellOnUseIncrementName);
@@ -328,7 +328,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 				MagicSpells.error("Invalid spell-on-use-increment defined for " + this.internalName);
 			}
 		}
-		
+
 		// Check spell on cost
 		if (this.spellOnCostName != null) {
 			this.spellOnCost = MagicSpells.getSpellByInternalName(this.spellOnCostName);
@@ -337,17 +337,17 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 			}
 		}
 	}
-	
+
 	@Override
 	public boolean canCastWithItem() {
 		return this.castWithItem;
 	}
-	
+
 	@Override
 	public boolean canCastByCommand() {
 		return this.castByCommand;
 	}
-	
+
 	@Override
 	public final PostCastAction castSpell(Player player, SpellCastState state, float power, String[] args) {
 		Player target;
@@ -372,13 +372,13 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (!(target instanceof Player)) return false;
 		return activate(caster, (Player)target, power, MagicSpells.NULL_ARGS, true) == PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
 		if (!(target instanceof Player)) return false;
 		return activate(null, (Player)target, power, MagicSpells.NULL_ARGS, true) == PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private PostCastAction activate(Player caster, Player target, float power, String[] args, boolean normal) {
 		if (isActive(target)) {
 			if (this.toggle) {
@@ -411,19 +411,19 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	public abstract boolean castBuff(Player player, float power, String[] args);
-	
+
 	public boolean recastBuff(Player player, float power, String[] args) {
 		return true;
 	}
-	
+
 	public void setAsEverlasting() {
 		this.duration = 0;
 		this.numUses = 0;
 		this.useCostInterval = 0;
 	}
-	
+
 	/**
 	 * Begins counting the spell duration for a player
 	 * @param player the player to begin counting duration
@@ -444,13 +444,13 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 				}
 			}, Math.round(dur * TimeUtil.TICKS_PER_SECOND) + 20); // overestimate ticks, since the duration is real-time ms based
 		}
-		
+
 		playSpellEffectsBuff(player, entity -> thisSpell.isActiveAndNotExpired((Player)entity));
-		
+
 		BuffManager buffman = MagicSpells.getBuffManager();
 		if (buffman != null) buffman.addBuff(player, this);
 	}
-	
+
 	/**
 	 * Checks whether the spell's duration has expired for a player
 	 * @param player the player to check
@@ -463,19 +463,19 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (endTime > System.currentTimeMillis()) return false;
 		return true;
 	}
-	
+
 	public boolean isActiveAndNotExpired(Player player) {
 		if (this.duration > 0 && isExpired(player)) return false;
 		return isActive(player);
 	}
-	
+
 	/**
 	 * Checks if this buff spell is active for the specified player
 	 * @param player the player to check
 	 * @return true if the spell is active, false otherwise
 	 */
 	public abstract boolean isActive(Player player);
-	
+
 	/**
 	 * Adds a use to the spell for the player. If the number of uses exceeds the amount allowed, the spell will immediately expire.
 	 * This does not automatically charge the use cost.
@@ -485,7 +485,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected int addUse(Player player) {
 		// Run spell on use increment first thing in case we want to intervene
 		if (this.spellOnUseIncrement != null) this.spellOnUseIncrement.cast(player, 1F, null);
-		
+
 		if (this.numUses > 0 || (this.reagents != null && this.useCostInterval > 0)) {
 			String playerName = player.getName();
 			Integer uses = this.useCounter.get(playerName);
@@ -494,7 +494,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 			} else {
 				uses++;
 			}
-			
+
 			if (this.numUses > 0 && uses >= this.numUses) {
 				turnOff(player);
 			} else {
@@ -504,7 +504,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		}
 		return 0;
 	}
-	
+
 	/**
 	 * Removes this spell's use cost from the player's inventory. If the reagents aren't available, the spell will expire.
 	 * @param player the player to remove the cost from
@@ -513,15 +513,15 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected boolean chargeUseCost(Player player) {
 		// Run spell on cost first thing to dodge the early returns and allow intervention
 		if (this.spellOnCost != null) this.spellOnCost.cast(player, 1F, null);
-		
+
 		if (this.reagents == null) return true;
 		if (this.useCostInterval <= 0) return true;
 		if (this.useCounter == null) return true;
-		
+
 		String playerName = player.getName();
 		Integer uses = this.useCounter.get(playerName);
 		if (uses == null) return true;
-		
+
 		if (uses % this.useCostInterval == 0) {
 			if (hasReagents(player, this.reagents)) {
 				removeReagents(player, this.reagents);
@@ -532,7 +532,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		}
 		return true;
 	}
-	
+
 	/**
 	 * Adds a use to the spell for the player. If the number of uses exceeds the amount allowed, the spell will immediately expire.
 	 * Removes this spell's use cost from the player's inventory. This does not return anything, to get useful return values, use
@@ -543,7 +543,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		addUse(player);
 		chargeUseCost(player);
 	}
-	
+
 	/**
 	 * Turns off this spell for the specified player. This can be called from many situations, including when the spell expires or the uses run out.
 	 * When overriding this function, you should always be sure to call super.turnOff(player).
@@ -561,21 +561,21 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		turnOffBuff(player);
 		cancelEffects(EffectPosition.CASTER, player.getUniqueId().toString());
 	}
-	
+
 	protected abstract void turnOffBuff(Player player);
-	
+
 	@Override
 	protected abstract void turnOff();
-	
+
 	@Override
 	public boolean isBeneficialDefault() {
 		return true;
 	}
-	
+
 	public boolean isTargeted() {
 		return this.targeted;
 	}
-	
+
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
 		Player player = event.getPlayer();
@@ -583,9 +583,9 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (!isExpired(player)) return;
 		turnOff(player);
 	}
-	
+
 	public class DamageListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 		public void onPlayerDamage(EntityDamageEvent event) {
 			Entity eventEntity = event.getEntity();
@@ -602,22 +602,22 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 				}
 			}
 		}
-		
+
 	}
-	
+
 	public class DeathListener implements Listener {
-		
+
 		@EventHandler
 		public void onPlayerDeath(PlayerDeathEvent event) {
 			Player player = event.getEntity();
 			if (!isActive(player)) return;
 			turnOff(player);
 		}
-		
+
 	}
-	
+
 	public class TeleportListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.LOWEST)
 		public void onTeleport(PlayerTeleportEvent event) {
 			Player player = event.getPlayer();
@@ -629,40 +629,40 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 				}
 			}
 		}
-		
+
 	}
-	
+
 	public class ChangeWorldListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.LOWEST)
 		public void onChangeWorld(PlayerChangedWorldEvent event) {
 			if (isActive(event.getPlayer())) {
 				turnOff(event.getPlayer());
 			}
 		}
-		
+
 	}
-	
+
 	public class SpellCastListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 		public void onChangeWorld(SpellCastEvent event) {
 			if (thisSpell != event.getSpell() && event.getSpellCastState() == SpellCastState.NORMAL && isActive(event.getCaster())) {
 				turnOff(event.getCaster());
 			}
 		}
-		
+
 	}
 
 	public class QuitListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.MONITOR)
 		public void onPlayerQuit(PlayerQuitEvent event) {
 			if (isActive(event.getPlayer())) {
 				turnOff(event.getPlayer());
 			}
 		}
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
@@ -23,9 +23,9 @@ import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.ValidTargetList;
 
 public class ExternalCommandSpell extends TargetedSpell implements TargetedEntitySpell {
-	
+
 	static MessageBlocker messageBlocker;
-	
+
 	private boolean castWithItem;
 	private boolean castByCommand;
 	private List<String> commandToExecute;
@@ -43,13 +43,13 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 	String strBlockedOutput;
 	boolean doVariableReplacement;
 	boolean useTargetVariablesInstead;
-	
+
 	ConversationFactory convoFac;
 	private Prompt convoPrompt;
 
 	public ExternalCommandSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.castWithItem = getConfigBoolean("can-cast-with-item", true);
 		this.castByCommand = getConfigBoolean("can-cast-by-command", true);
 		this.commandToExecute = getConfigStringList("command-to-execute", null);
@@ -67,25 +67,25 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		this.strBlockedOutput = getConfigString("str-blocked-output", "");
 		this.doVariableReplacement = getConfigBoolean("do-variable-replacement", false);
 		this.useTargetVariablesInstead = getConfigBoolean("use-target-variables-instead", false);
-		
+
 		if (this.requirePlayerTarget) this.validTargetList = new ValidTargetList(true, false);
-		
+
 		if (this.blockChatOutput) {
 			if (Bukkit.getPluginManager().isPluginEnabled("ProtocolLib")) {
 				if (messageBlocker == null) messageBlocker = new MessageBlocker();
 			} else {
 				this.convoPrompt = new StringPrompt() {
-					
+
 					@Override
 					public String getPromptText(ConversationContext context) {
 						return strBlockedOutput;
 					}
-					
+
 					@Override
 					public Prompt acceptInput(ConversationContext context, String input) {
 						return Prompt.END_OF_CONVERSATION;
 					}
-					
+
 				};
 				this.convoFac = new ConversationFactory(MagicSpells.plugin)
 					.withModality(true)
@@ -112,7 +112,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private void process(CommandSender sender, Player target, String[] args) {
 		// Get actual sender
 		CommandSender actualSender;
@@ -124,7 +124,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			actualSender = sender;
 		}
 		if (actualSender == null) return;
-		
+
 		// Grant permissions and op
 		boolean opped = false;
 		if (actualSender instanceof Player) {
@@ -139,7 +139,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 				actualSender.setOp(true);
 			}
 		}
-		
+
 		// Perform commands
 		try {
 			if (this.commandToExecute != null && !this.commandToExecute.isEmpty()) {
@@ -153,7 +153,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 						convo.begin();
 					}
 				}
-				
+
 				int delay = 0;
 				Player varOwner;
 				if (!this.useTargetVariablesInstead) {
@@ -195,10 +195,10 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			// Catch all exceptions to make sure we don't leave someone opped
 			e.printStackTrace();
 		}
-		
+
 		// Deop
 		if (opped) actualSender.setOp(false);
-		
+
 		// Effects
 		if (sender instanceof Player) {
 			if (target != null) {
@@ -232,7 +232,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		}
 		return false;
 	}
-	
+
 	@Override
 	public boolean castFromConsole(CommandSender sender, String[] args) {
 		if (!this.requirePlayerTarget) {
@@ -241,7 +241,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		}
 		return false;
 	}
-	
+
 	@EventHandler
 	public void onPlayerCommandPreprocess(PlayerCommandPreprocessEvent event) {
 		if (event.getPlayer().isOp()) return;
@@ -251,7 +251,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		for (String comm : this.commandToBlock) {
 			comm = comm.trim();
 			if (comm.isEmpty()) continue;
-			
+
 			if (msg.startsWith("/" + this.commandToBlock)) {
 				event.setCancelled(true);
 				sendMessage(this.strCantUseCommand, event.getPlayer(), MagicSpells.NULL_ARGS);
@@ -259,7 +259,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			}
 		}
 	}
-	
+
 	public boolean requiresPlayerTarget() {
 		return this.requirePlayerTarget;
 	}
@@ -273,24 +273,24 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 	public boolean canCastWithItem() {
 		return this.castWithItem;
 	}
-	
+
 	@Override
 	public void turnOff() {
 		if (messageBlocker == null) return;
 		messageBlocker.turnOff();
 		messageBlocker = null;
 	}
-	
+
 	private class DelayedCommand implements Runnable {
 
 		private CommandSender sender;
 		private Player target;
-		
+
 		public DelayedCommand(CommandSender sender, Player target) {
 			this.sender = sender;
 			this.target = target;
 		}
-		
+
 		@Override
 		public void run() {
 			// Get actual sender
@@ -303,7 +303,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 				actualSender = this.sender;
 			}
 			if (actualSender == null) return;
-			
+
 			// Grant permissions
 			boolean opped = false;
 			if (actualSender instanceof Player) {
@@ -318,7 +318,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 					actualSender.setOp(true);
 				}
 			}
-			
+
 			// Run commands
 			try {
 				Conversation convo = null;
@@ -346,10 +346,10 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 				// Catch exceptions to make sure we don't leave someone opped
 				e.printStackTrace();
 			}
-			
+
 			// Deop
 			if (opped) actualSender.setOp(false);
-			
+
 			// Graphical effect
 			if (this.sender != null) {
 				if (this.sender instanceof Player) {
@@ -359,7 +359,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 				}
 			}
 		}
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -35,6 +35,8 @@ import com.nisovin.magicspells.util.SpellType;
 import com.nisovin.magicspells.util.SpellTypes;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 @SpellType(types={SpellTypes.TARGETED_ENTITY_SPELL, SpellTypes.TARGETED_LOCATION_SPELL})
 public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
@@ -152,6 +154,12 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				Block block = getTargetedBlock(player, power);
 				if (block == null || block.getType() == Material.AIR) return noTarget(player);
 				locTarget = block.getLocation();
+
+				SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, locTarget, power);
+				EventUtil.call(event);
+				if (event.isCancelled()) return noTarget(player);
+				locTarget = event.getTargetLocation();
+				power = event.getPower();
 			}
 
 			open(player, opener, entityTarget, locTarget, power, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -40,39 +40,39 @@ import com.nisovin.magicspells.util.Util;
 public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
 	Random random = new Random();
-	
+
 	@ConfigData(field="title", dataType="String", defaultValue="Window Title  + <spellName>")
 	String title;
-	
+
 	@ConfigData(field="delay", dataType="int", defaultValue="0")
 	int delay;
-	
+
 	@ConfigData(field="require-entity-target", dataType="boolean", defaultValue="false")
 	boolean requireEntityTarget;
-	
+
 	@ConfigData(field="require-location-target", dataType="boolean", defaultValue="false")
 	boolean requireLocationTarget;
-	
+
 	@ConfigData(field="target-opens-menu-instead", dataType="boolean", defaultValue="false")
 	boolean targetOpensMenuInstead;
-	
+
 	@ConfigData(field="bypass-normal-cast", dataType="boolean", defaultValue="true")
 	boolean bypassNormalCast;
-	
+
 	@ConfigData(field="unique-names", dataType="boolean", defaultValue="false")
 	boolean uniqueNames;
-	
+
 	Map<String, MenuOption> options = new LinkedHashMap<>();
-	
+
 	int size = 9;
-	
+
 	Map<String, Float> castPower = new HashMap<>();
 	Map<String, LivingEntity> castEntityTarget = new HashMap<>();
 	Map<String, Location> castLocTarget = new HashMap<>();
-	
+
 	public MenuSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.title = ChatColor.translateAlternateColorCodes('&', getConfigString("title", "Window Title " + spellName));
 		this.delay = getConfigInt("delay", 0);
 		this.requireEntityTarget = getConfigBoolean("require-entity-target", false);
@@ -80,7 +80,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		this.targetOpensMenuInstead = getConfigBoolean("target-opens-menu-instead", false);
 		this.bypassNormalCast = getConfigBoolean("bypass-normal-cast", true);
 		this.uniqueNames = getConfigBoolean("unique-names", false);
-		
+
 		int maxSlot = 8;
 		for (String optionName : getConfigKeys("options")) {
 			int optionSlot = getConfigInt("options." + optionName + ".slot", -1);
@@ -112,14 +112,14 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 		}
 		this.size = ((maxSlot / 9) * 9) + 9;
-		
+
 		if (this.options.isEmpty()) MagicSpells.error("The MenuSpell '" + spellName + "' has no menu options!");
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
-		
+
 		for (MenuOption option : this.options.values()) {
 			Subspell spell = new Subspell(option.spellName);
 			if (spell.process()) {
@@ -130,15 +130,15 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 		}
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(Player player, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			LivingEntity entityTarget = null;
 			Location locTarget = null;
-			
+
 			Player opener = player;
-			
+
 			if (this.requireEntityTarget) {
 				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(player, power);
 				if (targetInfo != null) entityTarget = targetInfo.getTarget();
@@ -153,16 +153,16 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				if (block == null || block.getType() == Material.AIR) return noTarget(player);
 				locTarget = block.getLocation();
 			}
-			
+
 			open(player, opener, entityTarget, locTarget, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	String getOptionKey(ItemStack item) {
 		return item.getType().name() + '_' + item.getDurability() + '_' + item.getItemMeta().getDisplayName();
 	}
-	
+
 	void open(final Player caster, Player opener, LivingEntity entityTarget, Location locTarget, final float power, final String[] args) {
 		if (this.delay < 0) {
 			openMenu(caster, opener, entityTarget, locTarget, power, args);
@@ -173,16 +173,16 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			MagicSpells.scheduleDelayedTask(() -> openMenu(caster, p, e, l, power, args), this.delay);
 		}
 	}
-	
+
 	void openMenu(Player caster, Player opener, LivingEntity entityTarget, Location locTarget, float power, String[] args) {
 		this.castPower.put(opener.getName(), power);
 		if (this.requireEntityTarget && entityTarget != null) this.castEntityTarget.put(opener.getName(), entityTarget);
 		if (this.requireLocationTarget && locTarget != null) this.castLocTarget.put(opener.getName(), locTarget);
-		
+
 		Inventory inv = Bukkit.createInventory(opener, this.size, this.title);
 		applyOptionsToInventory(opener, inv, args);
 		opener.openInventory(inv);
-		
+
 		if (entityTarget != null && caster != null) {
 			playSpellEffects(caster, entityTarget);
 		} else {
@@ -191,7 +191,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			if (locTarget != null) playSpellEffects(EffectPosition.TARGET, locTarget);
 		}
 	}
-	
+
 	void applyOptionsToInventory(Player opener, Inventory inv, String[] args) {
 		inv.clear();
 		for (MenuOption option : this.options.values()) {
@@ -216,16 +216,16 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 		}
 	}
-	
+
 	@EventHandler
 	public void onInvClick(InventoryClickEvent event) {
 		if (event.getInventory().getTitle().equals(this.title)) {
-			event.setCancelled(true);		
+			event.setCancelled(true);
 			if (event.getClick() == ClickType.LEFT) {
 				final Player player = (Player)event.getWhoClicked();
 				String playerName = player.getName();
 				boolean close = true;
-				
+
 				ItemStack item = event.getCurrentItem();
 				if (item != null) {
 					String key = this.uniqueNames ? getOptionKey(item) : Util.getLoreData(item);
@@ -250,11 +250,11 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 						if (option.stayOpen) close = false;
 					}
 				}
-				
+
 				this.castPower.remove(playerName);
 				this.castEntityTarget.remove(playerName);
 				this.castLocTarget.remove(playerName);
-				
+
 				if (close) {
 					MagicSpells.scheduleDelayedTask(player::closeInventory, 0);
 				} else {
@@ -263,7 +263,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 		}
 	}
-	
+
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
 		String playerName = event.getPlayer().getName();
@@ -304,7 +304,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	public boolean castAtLocation(Location target, float power) {
 		return false;
 	}
-	
+
 	@Override
 	public boolean castFromConsole(CommandSender sender, String[] args) {
 		if (args.length >= 1) {
@@ -317,9 +317,9 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		}
 		return false;
 	}
-	
+
 	class MenuOption {
-		
+
 		String menuOptionName;
 		int slot;
 		ItemStack item;
@@ -329,7 +329,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		List<String> modifierList;
 		ModifierSet menuOptionModifiers;
 		boolean stayOpen;
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -20,49 +20,52 @@ import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.util.ConfigData;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetEvent;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public final class TargetedMultiSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
 	private static final Pattern DELAY_PATTERN = Pattern.compile("DELAY [0-9]+");
-	
+
 	@ConfigData(field="check-individual-cooldowns", dataType="boolean", defaultValue="false")
 	private boolean checkIndividualCooldowns;
-	
+
 	@ConfigData(field="require-entity-target", dataType="boolean", defaultValue="false")
 	private boolean requireEntityTarget;
-	
+
 	@ConfigData(field="point-blank", dataType="boolean", defaultValue="false")
 	private boolean pointBlank;
-	
+
 	@ConfigData(field="y-offset", dataType="int", defaultValue="0")
 	private int yOffset;
-	
+
 	@ConfigData(field="cast-random-spell-instead", dataType="boolean", defaultValue="false")
 	private boolean castRandomSpellInstead;
-	
+
 	@ConfigData(field="stop-on-fail", dataType="boolean", defaultValue="true")
 	boolean stopOnFail;
-	
+
 	@ConfigData(field="spells", dataType="String[]", defaultValue="null")
 	private List<String> spellList;
-	
+
 	private ArrayList<Action> actions;
 	private Random random = new Random();
-	
+
 	public TargetedMultiSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.checkIndividualCooldowns = getConfigBoolean("check-individual-cooldowns", false);
 		this.requireEntityTarget = getConfigBoolean("require-entity-target", false);
 		this.pointBlank = getConfigBoolean("point-blank", false);
 		this.yOffset = getConfigInt("y-offset", 0);
 		this.castRandomSpellInstead = getConfigBoolean("cast-random-spell-instead", false);
 		this.stopOnFail = getConfigBoolean("stop-on-fail", true);
-		
+
 		this.actions = new ArrayList<>();
 		this.spellList = getConfigStringList("spells", null);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -98,7 +101,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 					return PostCastAction.ALREADY_HANDLED;
 				}
 			}
-			
+
 			// Get target
 			Location locTarget = null;
 			LivingEntity entTarget = null;
@@ -120,13 +123,34 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 					b = null;
 				}
 			}
+			//handle target modifiers
+			if (entTarget != null) {
+				SpellTargetEvent event = new SpellTargetEvent(this, player, entTarget, power);
+				EventUtil.call(event);
+				if (event.isCancelled()) {
+					entTarget = null;
+				} else {
+					entTarget = event.getTarget();
+					power = event.getPower();
+				}
+			}
+			if (locTarget != null) {
+				locTarget.setY(locTarget.getY() + this.yOffset);
+				SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, locTarget, power);
+				EventUtil.call(event);
+				if (event.isCancelled()) {
+					locTarget = null;
+				} else {
+					locTarget = event.getTargetLocation();
+					power = event.getPower();
+				}
+			}
 			if (locTarget == null && entTarget == null) return noTarget(player);
-			if (locTarget != null) locTarget.setY(locTarget.getY() + this.yOffset);
-			
+
 			boolean somethingWasDone = runSpells(player, entTarget, locTarget, power);
-			
+
 			if (!somethingWasDone) return noTarget(player);
-			
+
 			if (entTarget != null) {
 				sendMessages(player, entTarget);
 				return PostCastAction.NO_MESSAGES;
@@ -139,10 +163,10 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 	public boolean castAtLocation(Player caster, Location target, float power) {
 		return runSpells(caster, null, target, power);
 	}
-	
+
 	@Override
 	public boolean castAtLocation(Location location, float power) {
-		return runSpells(null, null, location, power);
+		return castAtLocation(null, location, power);
 	}
 
 	@Override
@@ -152,9 +176,9 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		return runSpells(null, target, null, power);
+		return castAtEntity(null, target, power);
 	}
-	
+
 	boolean runSpells(Player player, LivingEntity entTarget, Location locTarget, float power) {
 		boolean somethingWasDone = false;
 		if (!this.castRandomSpellInstead) {
@@ -208,67 +232,63 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 		}
 		return somethingWasDone;
 	}
-	
+
 	boolean castTargetedSpell(Subspell spell, Player caster, LivingEntity entTarget, Location locTarget, float power) {
 		boolean success = false;
-		if (spell.isTargetedEntitySpell() && entTarget != null) {
+		if (spell.canTargetEntity() && entTarget != null) {
 			success = spell.castAtEntity(caster, entTarget, power);
-		} else if (spell.isTargetedLocationSpell()) {
-			if (entTarget != null) {
-				success = spell.castAtLocation(caster, entTarget.getLocation(), power);
-			} else if (locTarget != null) {
-				success = spell.castAtLocation(caster, locTarget, power);
-			}
+		} else if (spell.isTargetedLocationSpell() && locTarget != null) {
+			success = spell.castAtLocation(caster, locTarget, power);
 		} else {
 			success = spell.cast(caster, power) == PostCastAction.HANDLE_NORMALLY;
 		}
 		return success;
 	}
-	
+
 	private class Action {
-		
+
 		private Subspell spell;
 		private int delay;
-		
+
 		public Action(Subspell spell) {
 			this.spell = spell;
 			this.delay = 0;
 		}
-		
+
 		public Action(int delay) {
 			this.delay = delay;
 			this.spell = null;
 		}
-		
+
 		public boolean isSpell() {
 			return this.spell != null;
 		}
-		
+
 		public Subspell getSpell() {
 			return this.spell;
 		}
-		
+
 		public boolean isDelay() {
 			return this.delay > 0;
 		}
-		
+
 		public int getDelay() {
 			return this.delay;
 		}
-		
+
 	}
-	
+
 	private class DelayedSpell implements Runnable {
-		
+
 		private Subspell spell;
 		private Player player;
 		private LivingEntity entTarget;
 		private Location locTarget;
 		private float power;
-		
+
 		private List<DelayedSpell> delayedSpells;
 		private boolean cancelled;
-		
+
 		public DelayedSpell(Subspell spell, Player player, LivingEntity entTarget, Location locTarget, float power, List<DelayedSpell> delayedSpells) {
 			this.spell = spell;
 			this.player = player;
@@ -278,12 +298,12 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			this.delayedSpells = delayedSpells;
 			this.cancelled = false;
 		}
-		
+
 		public void cancel() {
 			this.cancelled = true;
 			this.delayedSpells = null;
 		}
-		
+
 		public void cancelAll() {
 			for (DelayedSpell ds : this.delayedSpells) {
 				if (ds == this) continue;
@@ -292,7 +312,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			this.delayedSpells.clear();
 			cancel();
 		}
-		
+
 		@Override
 		public void run() {
 			if (!this.cancelled) {
@@ -306,7 +326,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			}
 			this.delayedSpells = null;
 		}
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -124,16 +124,6 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 				}
 			}
 			//handle target modifiers
-			if (entTarget != null) {
-				SpellTargetEvent event = new SpellTargetEvent(this, player, entTarget, power);
-				EventUtil.call(event);
-				if (event.isCancelled()) {
-					entTarget = null;
-				} else {
-					entTarget = event.getTarget();
-					power = event.getPower();
-				}
-			}
 			if (locTarget != null) {
 				locTarget.setY(locTarget.getY() + this.yOffset);
 				SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, locTarget, power);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -178,7 +178,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell {
 					EventUtil.call(event);
 					if (event.isCancelled()) continue;
 
-					if (spell != null && spell.isTargetedEntitySpell()) spell.castAtEntity(this.caster, event.getTarget(), event.getPower());
+					if (spell != null && spell.canTargetEntity()) spell.castAtEntity(this.caster, event.getTarget(), event.getPower());
 					playSpellEffects(EffectPosition.TARGET, event.getTarget());
 					this.immune.add(e);
 					if (stopOnHitEntity) break mainLoop;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/FirenovaSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/FirenovaSpell.java
@@ -25,6 +25,8 @@ import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.events.SpellTargetEvent;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 // TODO make this a targeted spell
 
@@ -43,13 +45,13 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 	boolean burnTallGrass;
 	private boolean checkPlugins;
 	int expandRate = 1;
-	
+
 	HashSet<Player> fireImmunity;
 	Subspell subSpell = null;
-	
+
 	// Using the names to be version safe
 	private Set<String> activeDamageCauses = null;
-	
+
 	private static final Map<String, Set<String>> materialsToImmunities = new HashMap<>();
 	static {
 		materialsToImmunities.put("FIRE", Sets.newHashSet("FIRE", "FIRE_TICK"));
@@ -58,25 +60,25 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 		materialsToImmunities.put("MAGMA", Sets.newHashSet("HOT_FLOOR"));
 		materialsToImmunities.put("CACTUS", Sets.newHashSet("CONTACT"));
 	}
-	
+
 	public FirenovaSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		range = getConfigInt("range", 3);
 		tickSpeed = getConfigInt("tick-speed", 5);
 		burnTallGrass = getConfigBoolean("burn-tall-grass", true);
 		checkPlugins = getConfigBoolean("check-plugins", true);
-		
+
 		mat = MagicSpells.getItemNameResolver().resolveBlock(getConfigString("block-type", "51:15"));
-		
+
 		expandRate = getConfigInt("expanding-radius-change", expandRate);
 		if (expandRate < 1) expandRate = 1;
-		
+
 		if (materialsToImmunities.containsKey(mat.getMaterial().name())) {
 			activeDamageCauses = materialsToImmunities.get(mat.getMaterial().name());
 			fireImmunity = new HashSet<>();
 		}
-		
+
 		subSpell = new Subspell(getConfigString("spell", ""));
 		if (!subSpell.process()) subSpell = null;
 		if (subSpell != null) {
@@ -113,7 +115,7 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 		if (this.activeDamageCauses == null) return;
 		if (!this.activeDamageCauses.contains(event.getCause().name())) return;
 		Player player = (Player)event.getEntity();
-		
+
 		if (this.fireImmunity.contains(player)) {
 			// Caster is taking damage, cancel it
 			event.setCancelled(true);
@@ -135,26 +137,26 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 			}
 		}
 	}
-	
+
 	private class FirenovaAnimation implements Runnable {
-		
+
 		Player player;
 		int i = 0;
 		Block center;
 		HashSet<Block> fireBlocks = new HashSet<>();
 		int taskId;
-		
+
 		public FirenovaAnimation(Player caster) {
 			this.player = caster;
 			this.center = caster.getLocation().getBlock();
 			this.taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickSpeed);
 		}
-		
+
 		public FirenovaAnimation(Location location) {
 			this.center = location.getBlock();
 			this.taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickSpeed);
 		}
-		
+
 		@Override
 		public void run() {
 			// Remove old fire blocks
@@ -163,7 +165,7 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 				block.setType(Material.AIR);
 			}
 			this.fireBlocks.clear();
-			
+
 			this.i += expandRate;
 			if (i <= range) {
 				// Set next ring on fire
@@ -200,7 +202,7 @@ public class FirenovaSpell extends InstantSpell implements TargetedLocationSpell
 				}
 			}
 		}
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ItemBombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ItemBombSpell.java
@@ -27,10 +27,10 @@ public class ItemBombSpell extends InstantSpell implements TargetedLocationSpell
 	int delay;
 	Subspell spell;
 	boolean itemHasGravity;
-	
+
 	public ItemBombSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.velocity = getConfigFloat("velocity", 1);
 		this.verticalAdjustment = getConfigFloat("vertical-adjustment", 0.5F);
 		this.rotationOffset = getConfigInt("rotation-offset", 0);
@@ -41,11 +41,11 @@ public class ItemBombSpell extends InstantSpell implements TargetedLocationSpell
 		this.delay = getConfigInt("delay", 100);
 		this.itemHasGravity = getConfigBoolean("gravity", true);
 		this.spell = new Subspell(getConfigString("spell", ""));
-		
+
 		if (this.item == null) MagicSpells.error("Invalid item on ItemBombSpell " + this.internalName);
 		if (this.itemName != null) this.itemName = ChatColor.translateAlternateColorCodes('&', this.itemName);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -62,7 +62,7 @@ public class ItemBombSpell extends InstantSpell implements TargetedLocationSpell
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private void spawnItem(final Player player, Location l, final float power) {
 		Vector v = getVector(l, power);
 		final Item i = l.getWorld().dropItem(l, this.item);
@@ -82,14 +82,14 @@ public class ItemBombSpell extends InstantSpell implements TargetedLocationSpell
 				spell.castAtLocation(player, l, power);
 			}
 		}, this.delay);
-		
+
 		if (player != null) {
 			playSpellEffects(EffectPosition.CASTER, player);
 		} else {
 			playSpellEffects(EffectPosition.CASTER, l);
 		}
 	}
-	
+
 	private Vector getVector(Location loc, float power) {
 		Vector v = loc.getDirection();
 		if (this.verticalAdjustment != 0) v.setY(v.getY() + this.verticalAdjustment);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ItemProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ItemProjectileSpell.java
@@ -28,23 +28,23 @@ public class ItemProjectileSpell extends InstantSpell {
 	ItemStack item;
 	Subspell spellOnHitEntity;
 	Subspell spellOnHitGround;
-	
+
 	public ItemProjectileSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.speed = getConfigFloat("speed", 1);
 		this.vertSpeedUsed = configKeyExists("vert-speed");
 		this.vertSpeed = getConfigFloat("vert-speed", 0);
 		this.hitRadius = getConfigFloat("hit-radius", 1);
 		this.yOffset = getConfigFloat("y-offset", 0);
 		this.projectileHasGravity = getConfigBoolean("gravity", true);
-		
+
 		if (configKeyExists("spell-on-hit-entity")) this.spellOnHitEntity = new Subspell(getConfigString("spell-on-hit-entity", ""));
 		if (configKeyExists("spell-on-hit-ground")) this.spellOnHitGround = new Subspell(getConfigString("spell-on-hit-ground", ""));
-		
+
 		this.item = Util.getItemStackFromString(getConfigString("item", "iron_sword"));
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -65,9 +65,9 @@ public class ItemProjectileSpell extends InstantSpell {
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	class ItemProjectile implements Runnable {
-		
+
 		Player caster;
 		float power;
 		Item entity;
@@ -75,7 +75,7 @@ public class ItemProjectileSpell extends InstantSpell {
 		Vector vel;
 		int taskId;
 		int groundCount = 0;
-		
+
 		public ItemProjectile(Player caster, float power) {
 			this.caster = caster;
 			this.power = power;
@@ -93,10 +93,10 @@ public class ItemProjectileSpell extends InstantSpell {
 			this.entity.teleport(location);
 			this.entity.setPickupDelay(1000000);
 			this.entity.setVelocity(this.vel);
-			
+
 			this.taskId = MagicSpells.scheduleRepeatingTask(this, 3, 3);
 		}
-		
+
 		@Override
 		public void run() {
 			for (Entity e : this.entity.getNearbyEntities(hitRadius, hitRadius + 0.5, hitRadius)) {
@@ -120,12 +120,12 @@ public class ItemProjectileSpell extends InstantSpell {
 				stop();
 			}
 		}
-		
+
 		void stop() {
 			this.entity.remove();
 			MagicSpells.cancelTask(this.taskId);
 		}
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
@@ -20,6 +20,7 @@ import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.util.BoundingBox;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.SpellReagents;
+import com.nisovin.magicspells.util.compat.EventUtil;
 
 public class PortalSpell extends InstantSpell {
 
@@ -260,8 +261,9 @@ public class PortalSpell extends InstantSpell {
 			}
 
 			SpellTargetEvent event = new SpellTargetEvent(this.spell, this.caster, player, 1);
-			Bukkit.getPluginManager().callEvent(event);
+			EventUtil.call(event);
 			if (payer != null) removeReagents(payer, PortalSpell.this.teleportCost);
+			if (event.isCancelled()) return false;
 			return true;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/PurgeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/PurgeSpell.java
@@ -20,15 +20,15 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.Util;
 
 public class PurgeSpell extends InstantSpell implements TargetedLocationSpell {
-	
+
 	private double radius;
 	private List<EntityType> entities;
-	
+
 	public PurgeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		this.radius = getConfigDouble("range", 15);
-		
+
 		List<String> list = getConfigStringList("entities", null);
 		if (list != null && !list.isEmpty()) {
 			this.entities = new ArrayList<>();
@@ -57,6 +57,11 @@ public class PurgeSpell extends InstantSpell implements TargetedLocationSpell {
 				if (entity instanceof Player) continue;
 				if (this.entities != null && !this.entities.contains(entity.getType())) continue;
 				if (!this.validTargetList.canTarget(player, entity)) continue;
+
+				SpellTargetEvent event = new SpellTargetEvent(this, player, (LivingEntity)entity, power);
+				EventUtil.call(event);
+				if (event.isCancelled()) continue;
+
 				((LivingEntity)entity).setHealth(0);
 				killed = true;
 				playSpellEffects(EffectPosition.TARGET, entity);
@@ -83,9 +88,11 @@ public class PurgeSpell extends InstantSpell implements TargetedLocationSpell {
 				} else {
 					if (!this.validTargetList.canTarget(e)) continue;
 				}
+
 				SpellTargetEvent event = new SpellTargetEvent(this, caster, (LivingEntity)e, power);
 				EventUtil.call(event);
 				if (event.isCancelled()) continue;
+
 				success = true;
 				((LivingEntity)e).setHealth(0);
 				playSpellEffects(EffectPosition.TARGET, e.getLocation());
@@ -101,6 +108,6 @@ public class PurgeSpell extends InstantSpell implements TargetedLocationSpell {
 	@Override
 	public boolean castAtLocation(Location target, float power) {
 		return castAtLocation(null, target, power);
-	}	
-	
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -22,7 +22,7 @@ import com.nisovin.magicspells.util.HandHandler;
 import com.nisovin.magicspells.util.MagicConfig;
 
 public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
-	
+
 	private int slot;
 	private boolean consumeBlock;
 	private Material[] allowedTypes;
@@ -30,10 +30,10 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 	private boolean playBreakEffect;
 	private String strInvalidBlock;
 	private String strCantBuild;
-	
+
 	public BuildSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		slot = getConfigInt("slot", 0);
 		consumeBlock = getConfigBoolean("consume-block", true);
 		String[] allowed = getConfigString("allowed-types", "1,2,3,4,5,12,13,17,20,22,24,35,41,42,43,44,45,47,48,49,50,53,57,65,67,80,85,87,88,89,91,92").split(",");
@@ -48,7 +48,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 		strInvalidBlock = getConfigString("str-invalid-block", "You can't build that block.");
 		strCantBuild = getConfigString("str-cant-build", "You can't build there.");
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(Player player, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
@@ -58,7 +58,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 				// Fail
 				return noTarget(player, strInvalidBlock);
 			}
-			
+
 			// Get target
 			List<Block> lastBlocks = null;
 			try {
@@ -109,16 +109,16 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 		return true;
 	}
-	
+
 	@Override
 	public boolean castAtLocation(Player caster, Location target, float power) {
 		// Get mat
 		ItemStack item = caster.getInventory().getItem(slot);
 		if (item == null || !isAllowed(item.getType())) return false;
-		
+
 		// Get blocks
 		Block block = target.getBlock();
-		
+
 		// Build
 		return build(caster, block, block, item);
 	}
@@ -127,7 +127,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 	public boolean castAtLocation(Location target, float power) {
 		return false;
 	}
-	
+
 	private boolean isAllowed(Material mat) {
 		if (!mat.isBlock()) return false;
 		for (int i = 0; i < allowedTypes.length; i++) {
@@ -135,5 +135,5 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 		return false;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
@@ -27,10 +27,10 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 	private int maxYForce;
 	private boolean addVelocityInstead;
 	private boolean callTargetEvents;
-	
+
 	public ForcebombSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		radiusSquared = getConfigDouble("radius", 3);
 		radiusSquared *= radiusSquared;
 		yOffset = getConfigFloat("y-offset", 0F);
@@ -75,7 +75,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 		knockback(null, target, power);
 		return true;
 	}
-	
+
 	public void knockback(Player player, Location location, float basePower) {
 		location = location.clone().add(0D, yOffset, 0D);
 	    Vector t = location.toVector();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
@@ -26,10 +26,10 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 	int resetTime;
 	float maxDuration;
 	float maxDistance;
-	
+
 	// TODO: fix leak
 	Map<String, CastData> casting = new HashMap<>();
-	
+
 	public HoldRightSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 		spell = new Subspell(getConfigString("spell", ""));
@@ -39,7 +39,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 		maxDuration = getConfigFloat("max-duration", 0F);
 		maxDistance = getConfigFloat("max-distance", 0F);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -68,7 +68,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 					data = new CastData(block.getLocation().add(0.5, 0.5, 0.5), power);
 				} else {
 					return noTarget(player);
-				}				
+				}
 			} else {
 				data = new CastData(power);
 			}
@@ -79,7 +79,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	@Override
 	public boolean castAtLocation(Player caster, Location target, float power) {
 		if (!targetLocation) return false;
@@ -117,29 +117,29 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 	public boolean castAtEntity(LivingEntity target, float power) {
 		return false;
 	}
-	
+
 	class CastData {
-		
+
 		long start = System.currentTimeMillis();
 		long lastCast = 0;
 		LivingEntity targetEntity = null;
 		Location targetLocation = null;
 		float power = 1f;
-		
+
 		public CastData(LivingEntity target, float power) {
 			targetEntity = target;
 			this.power = power;
 		}
-		
+
 		public CastData(Location target, float power) {
 			targetLocation = target;
 			this.power = power;
 		}
-		
+
 		public CastData(float power) {
 			this.power = power;
 		}
-		
+
 		boolean isValid(Player player) {
 			if (lastCast < System.currentTimeMillis() - resetTime) return false;
 			if (maxDuration > 0 && System.currentTimeMillis() - start > maxDuration * TimeUtil.MILLISECONDS_PER_SECOND) return false;
@@ -152,7 +152,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 			}
 			return true;
 		}
-		
+
 		void cast(Player caster) {
 			lastCast = System.currentTimeMillis();
 			if (targetEntity != null) {
@@ -163,7 +163,6 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 				spell.cast(caster, power);
 			}
 		}
-		
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
@@ -17,6 +17,8 @@ import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
@@ -65,7 +67,13 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 			} else if (targetLocation) {
 				Block block = getTargetedBlock(player, power);
 				if (block != null && block.getType() != Material.AIR) {
-					data = new CastData(block.getLocation().add(0.5, 0.5, 0.5), power);
+
+					SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, block.getLocation().add(0.5, 0.5, 0.5), power);
+					EventUtil.call(event);
+					if (event.isCancelled()) return noTarget(player);
+					power = event.getPower();
+
+					data = new CastData(event.getTargetLocation(), power);
 				} else {
 					return noTarget(player);
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -311,10 +311,8 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 					// Should we bounce the missile back?
 					if (!preImpact.getRedirected()) {
 						// Apparently didn't get redirected, carry out the plans
-						if (spell.isTargetedEntitySpell()) {
+						if (spell.canTargetEntity()) {
 							spell.castAtEntity(caster, target, power);
-						} else if (spell.isTargetedLocationSpell()) {
-							spell.castAtLocation(caster, target.getLocation(), power);
 						}
 						playSpellEffects(EffectPosition.TARGET, target);
 						stop();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -33,12 +33,12 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 	private boolean cancelOnItemSwitch;
 	private boolean cancelOnSpellCast;
 	private boolean cancelOnTakeDamage;
-	
+
 	HashMap<Player,Levitator> levitating;
-	
+
 	public LevitateSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		tickRate = getConfigInt("tick-rate", 5);
 		duration = getConfigInt("duration", 10);
 		distanceChange = getConfigFloat("distance-change", 0F);
@@ -46,10 +46,10 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		cancelOnItemSwitch = getConfigBoolean("cancel-on-item-switch", true);
 		cancelOnSpellCast = getConfigBoolean("cancel-on-spell-cast", false);
 		cancelOnTakeDamage = getConfigBoolean("cancel-on-take-damage", true);
-		
+
 		levitating = new HashMap<>();
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -66,14 +66,14 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		} else if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(player, power);
 			if (target == null) return noTarget(player);
-			
+
 			levitate(player, target.getTarget(), target.getPower());
 			sendMessages(player, target.getTarget());
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private void levitate(Player player, Entity target, float power) {
 		double distance = player.getLocation().distance(target.getLocation());
 		int duration = this.duration > 0 ? Math.round(this.duration * (20F/tickRate) * power) : 0;
@@ -92,52 +92,52 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 	public boolean castAtEntity(LivingEntity target, float power) {
 		return false;
 	}
-	
+
 	public void onPlayerDeath(PlayerDeathEvent event) {
 		if (!levitating.containsKey(event.getEntity())) return;
 		levitating.remove(event.getEntity()).stop();
 	}
-	
+
 	public class ItemSwitchListener implements Listener {
-		
+
 		@EventHandler
 		public void onItemSwitch(PlayerItemHeldEvent event) {
 			if (!levitating.containsKey(event.getPlayer())) return;
 			levitating.remove(event.getPlayer()).stop();
 		}
-		
+
 	}
-	
+
 	public class SpellCastListener implements Listener {
-		
+
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 		public void onSpellCast(SpellCastEvent event) {
 			if (levitating.containsKey(event.getCaster()) && !event.getSpell().getInternalName().equals(internalName)) {
 				levitating.remove(event.getCaster()).stop();
 			}
 		}
-		
+
 	}
-	
+
 	public class DamageListener implements Listener {
-		
+
 		@EventHandler
 		public void onEntityDamage(EntityDamageByEntityEvent event) {
 			if (event.getEntity() instanceof Player && levitating.containsKey(event.getEntity())) {
 				levitating.remove(event.getEntity()).stop();
 			}
 		}
-		
+
 	}
-	
+
 	@Override
 	public void turnOff() {
 		Util.forEachValueOrdered(levitating, Levitator::stop);
 		levitating.clear();
 	}
-	
+
 	private class Levitator implements Runnable {
-		
+
 		private Player caster;
 		private Entity target;
 		private int durationLevitator;
@@ -145,7 +145,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		private int counter;
 		private int taskId;
 		private boolean stopped;
-		
+
 		public Levitator(Player caster, Entity target, int duration, double distance) {
 			this.caster = caster;
 			this.target = target;
@@ -156,7 +156,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 			playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, caster.getLocation(), target.getLocation(), caster, target);
 			stopped = false;
 		}
-		
+
 		@Override
 		public void run() {
 			if (stopped) return;
@@ -178,13 +178,13 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 				if (durationLevitator > 0 && counter > durationLevitator) stop();
 			}
 		}
-		
+
 		public void stop() {
 			Bukkit.getScheduler().cancelTask(taskId);
 			stopped = true;
 			levitating.remove(caster);
 		}
-		
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -45,7 +45,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 	private boolean checkPlugins;
 	boolean playBreakEffect;
 	private String strFailed;
-	
+
 	//Pattern Configuration
 	private boolean usePattern;
 	private List<String> patterns;
@@ -303,7 +303,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 
 		if (resetDelay > 0 && !falling) {
 			Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, new Runnable() {
-				
+
 				@Override
 				public void run() {
 					if (materials.contains(block.getType())) {
@@ -313,12 +313,12 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 						if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
 					}
 				}
-				
+
 			}, resetDelay);
 		}
 		return true;
 	}
-	
+
 	@Override
 	public boolean castAtLocation(Player caster, Location target, float power) {
 		Block block = target.getBlock();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -151,7 +151,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell {
 		} else if (!entitySpell.process()) {
 			MagicSpells.error("Orbit Spell '" + internalName + "' has an invalid spell-on-hit-entity defined");
 			entitySpell = null;
-		} else if (!entitySpell.isTargetedEntitySpell() && !entitySpell.isTargetedEntityFromLocationSpell()) {
+		} else if (!entitySpell.canTargetEntity() && !entitySpell.isTargetedEntityFromLocationSpell()) {
 			MagicSpells.error("Orbit Spell '" + internalName + "' spell-on-hit-entity must be a targeted entity spell");
 			entitySpell = null;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemoveMarksSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemoveMarksSpell.java
@@ -17,6 +17,8 @@ import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.spells.instant.MarkSpell;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.MagicLocation;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class RemoveMarksSpell extends TargetedSpell implements TargetedLocationSpell {
 
@@ -56,6 +58,13 @@ public class RemoveMarksSpell extends TargetedSpell implements TargetedLocationS
 				if (b != null && b.getType() != Material.AIR) loc = b.getLocation();
 			}
 			if (loc == null) return noTarget(player);
+
+			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, loc, power);
+			EventUtil.call(event);
+			if (event.isCancelled()) return noTarget(player);
+			loc = event.getTargetLocation();
+			power = event.getPower();
+
 			removeMarks(player, loc, power);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemovePulsersSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemovePulsersSpell.java
@@ -17,6 +17,8 @@ import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.spells.targeted.PulserSpell;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.MagicLocation;
+import com.nisovin.magicspells.util.compat.EventUtil;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class RemovePulsersSpell extends TargetedSpell implements TargetedLocationSpell {
 
@@ -56,6 +58,13 @@ public class RemovePulsersSpell extends TargetedSpell implements TargetedLocatio
 				if (b != null && b.getType() != Material.AIR) loc = b.getLocation();
 			}
 			if (loc == null) return noTarget(player);
+
+			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, loc, power);
+			EventUtil.call(event);
+			if (event.isCancelled()) return noTarget(player);
+			loc = event.getTargetLocation();
+			power = event.getPower();
+
 			removePulsers(player, loc, power);
 		}
 		return PostCastAction.HANDLE_NORMALLY;


### PR DESCRIPTION
Massive overhaul to location-modifiers + an extension to target-modifiers

Semantics:
anytime a targetted spell is cast at a location, whether that be a location chosen by the caster or a location chosen by a parent spell, any location-modifiers attached to the spell should trigger
I also extended target-modifiers to be consistent with these semantics, anytime a targeted spell is cast at an entity, any target-modifiers attached to the spell should trigger
I took special care with changing target-modifiers so that the change would preserve backwards compatibility
with these changes is should always be possible to attach unique target and location modifiers to a spell that will always get processed when the spell is cast at a target or a location
the only exception is spells cast through castinstead, since this could crash the plugin via an infinite loop if it were allowed
