### PR TITLE
False Player Position Updating

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CloneKillListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CloneKillListener.java
@@ -1,0 +1,36 @@
+package com.nisovin.magicspells.spells.passive;
+
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.OverridePriority;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDeathEvent;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class CloneKillListener extends PassiveListener {
+
+
+    @Override
+    public void initialize(String var) {
+
+    }
+
+
+    @OverridePriority
+    @EventHandler
+    public void onDeath(EntityRemoveFromWorldEvent event){
+        if(event.getEntity() instanceof Display displayEntity && MagicSpells.getVolatileCodeHandler().isRelatedToFalsePlayer(displayEntity)){
+            //Using larger radius for situations where this would actually be triggered :3
+            Collection<LivingEntity> nearbyEntities = displayEntity.getLocation().getNearbyLivingEntities(20);
+            Bukkit.getLogger().info("Found: " + nearbyEntities.size());
+            if(nearbyEntities.size() > 0)   passiveSpell.activate(nearbyEntities.stream().findFirst().get());
+        }
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CloneMoveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CloneMoveListener.java
@@ -1,0 +1,45 @@
+package com.nisovin.magicspells.spells.passive;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.OverridePriority;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityTeleportEvent;
+
+import java.util.Collection;
+import java.util.Objects;
+
+public class CloneMoveListener extends PassiveListener {
+    @Override
+    public void initialize(String var) {
+
+    }
+
+
+    @OverridePriority
+    @EventHandler
+    public void onEntityTeleport(EntityTeleportEvent event){
+        if(event.getEntity() instanceof Display displayEntity){
+            if(MagicSpells.getVolatileCodeHandler().isRelatedToFalsePlayer(displayEntity)){
+                /*
+                    Magic Spells REQUIRES a LivingEntity to cast spells..
+                    Since a DisplayEntity is NOT considered a Living entity.. I needed to work around this.
+                    My Solution: Just find any nearby entites either where they left or where they end up
+                    there HAS to be one somewhere!
+                */
+                Collection<LivingEntity> nearbyEntities = displayEntity.getLocation().getNearbyLivingEntities(4);
+                if(nearbyEntities.size() == 0)
+                    nearbyEntities = Objects.requireNonNull(event.getTo()).getNearbyLivingEntities(4);
+                if(nearbyEntities.size() > 0){
+                    passiveSpell.activate(nearbyEntities.stream().findFirst().get(), null, event.getTo());
+                    //Just pull any entity and cast the spell using them?
+                }
+
+            }
+        }
+
+    }
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/UpdateAllClonesSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/UpdateAllClonesSpell.java
@@ -1,0 +1,22 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.MagicConfig;
+import net.kyori.adventure.text.Component;
+import org.bukkit.Bukkit;
+import org.bukkit.entity.LivingEntity;
+
+public class UpdateAllClonesSpell extends TargetedSpell {
+
+    public UpdateAllClonesSpell(MagicConfig config, String spellName) {
+        super(config, spellName);
+    }
+
+    @Override
+    public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
+        MagicSpells.getVolatileCodeHandler().updateAllFalsePlayers();
+        return PostCastAction.HANDLE_NORMALLY;
+    }
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/UpdateCloneSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/UpdateCloneSpell.java
@@ -1,0 +1,86 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.TargetedLocationSpell;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.config.ConfigData;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.Display;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UpdateCloneSpell extends TargetedSpell implements TargetedLocationSpell {
+
+    private ConfigData<Double> maxX;
+    private ConfigData<Double> maxY;
+    private ConfigData<Double> maxZ;
+    public UpdateCloneSpell(MagicConfig config, String spellName) {
+        super(config, spellName);
+
+        maxX = getConfigDataDouble("distance-x", 1);
+        maxY = getConfigDataDouble("distance-y", 1);
+        maxZ = getConfigDataDouble("distance-z", 1);
+
+    }
+
+    @Override
+    public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
+
+        Block block = getTargetedBlock(caster, power, args);
+
+        Collection<Entity> nearbyEntities = block.getLocation().getNearbyEntities(
+                maxX.get(caster, null, power, args),
+                maxY.get(caster, null, power, args),
+                maxZ.get(caster, null, power, args));
+
+        Bukkit.getLogger().info("I am checking for nearby block entities! " + nearbyEntities.size());
+        Bukkit.getLogger().info("Position: " + block.getX() + " | " + block.getY() + " | " + block.getZ());
+
+        for(Entity entity : nearbyEntities){
+            if(entity instanceof Display
+                    && MagicSpells.getVolatileCodeHandler().isRelatedToFalsePlayer((Display)entity)){
+                MagicSpells.getVolatileCodeHandler().updateFalsePlayer((Display)entity);
+            }
+        }
+        return PostCastAction.HANDLE_NORMALLY;
+    }
+
+
+    @Override
+    public boolean castAtLocation(LivingEntity caster, Location target, float power, String[] args) {
+        updateDisplays(caster, target, power);
+        return true;
+    }
+
+    @Override
+    public boolean castAtLocation(LivingEntity caster, Location target, float power) {
+        return castAtLocation(caster, target, power, null);
+    }
+
+    @Override
+    public boolean castAtLocation(Location target, float power) {return false;}
+
+
+    private void updateDisplays(LivingEntity caster, Location location, float power){
+        Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.getInstance(), () ->{
+            Collection<Entity> nearbyEntities = location.getNearbyEntities(
+                    maxX.get(caster, null, power, null),
+                    maxY.get(caster, null, power, null),
+                    maxZ.get(caster, null, power, null));
+
+            for(Entity entity : nearbyEntities){
+                if(entity instanceof Display
+                        && MagicSpells.getVolatileCodeHandler().isRelatedToFalsePlayer((Display)entity)){
+                    MagicSpells.getVolatileCodeHandler().updateFalsePlayer((Display)entity);
+                }
+            }
+        }, 5);  //Needed to add a slight delay because of the way EntityTeleportEvent works.
+    }
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -146,6 +146,8 @@ public class PassiveManager {
 		addListener("teleport", TeleportListener.class);
 		addListener("ticks", TicksListener.class);
 		addListener("unequip", UnequipListener.class);
+		addListener("clonekilled", CloneKillListener.class);
+		addListener("clonemoved", CloneMoveListener.class);
 		addListener("worldchange", WorldChangeListener.class);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -61,4 +61,19 @@ public class VolatileCodeDisabled extends VolatileCodeHandle {
 	public void removeFalsePlayer(int id) {
 
 	}
+
+	@Override
+	public boolean isRelatedToFalsePlayer(Display entityDisplay) {
+		return false;
+	}
+
+	@Override
+	public void updateFalsePlayer(Display entityDisplay) {
+
+	}
+
+	@Override
+	public void updateAllFalsePlayers() {
+
+	}
 }

--- a/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -33,4 +33,11 @@ public abstract class VolatileCodeHandle {
 	public abstract int createFalsePlayer(Player player, Location location, String pose, boolean cloneEquipment);
 
 	public abstract void removeFalsePlayer(int id);
+
+	public abstract boolean isRelatedToFalsePlayer(Display entityDisplay);
+
+	public abstract void updateFalsePlayer(Display entityDisplay);
+
+	public abstract void updateAllFalsePlayers();
+
 }

--- a/nms/v1_19_R1/src/main/java/com/nisovin/magicspells/volatilecode/v1_19_R1/VolatileCode1_19_R1.kt
+++ b/nms/v1_19_R1/src/main/java/com/nisovin/magicspells/volatilecode/v1_19_R1/VolatileCode1_19_R1.kt
@@ -131,7 +131,19 @@ class VolatileCode1_19_R1(helper: VolatileCodeHelper) : VolatileCodeHandle(helpe
     	return 0
     }
 
+    override fun isRelatedToFalsePlayer(entityDisplay: Display?): Boolean {
+        TODO("Not yet implemented")
+    }
+
 	override fun removeFalsePlayer(id: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateFalsePlayer(entityDisplay: Display) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAllFalsePlayers() {
         TODO("Not yet implemented")
     }
 }

--- a/nms/v1_19_R2/src/main/java/com/nisovin/magicspells/volatilecode/v1_19_R2/VolatileCode1_19_R2.kt
+++ b/nms/v1_19_R2/src/main/java/com/nisovin/magicspells/volatilecode/v1_19_R2/VolatileCode1_19_R2.kt
@@ -131,7 +131,19 @@ class VolatileCode1_19_R2(helper: VolatileCodeHelper) : VolatileCodeHandle(helpe
     	return 0
     }
 
+    override fun isRelatedToFalsePlayer(entityDisplay: Display?): Boolean {
+        TODO("Not yet implemented")
+    }
+
 	override fun removeFalsePlayer(id: Int) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateFalsePlayer(entityDisplay: Display) {
+        TODO("Not yet implemented")
+    }
+
+    override fun updateAllFalsePlayers() {
         TODO("Not yet implemented")
     }
 }


### PR DESCRIPTION
This contains the following:

1: UpdateAllClones
  Loops through every clone and updates their position with where the linked BlockDisplay is. As well if the block display does not exist then it will automatically remove the clone on call.

2: UpdateClone
  Triggers a ray cast from the position of the caster to obtain a block location (or uses passed location if exists) and then updates any linked Clones for display entities within a distance from the Block Displays.

3: Passive Spell - clonemoved
  Triggers every time a block display linked to a Player clone is teleported. Will then trigger any requested spell (In my video I linked it to the UpdateClone spell). I did not have it auto-trigger the update in case there would be some want to do something different.

4: Passive Spell - clonekilled
  This one is not fully functional. TLDR is when the Block Display is removed from the world for any reason (in my example case using /kill) the set spell will trigger. However, this did not always trigger the spell.

Some issues I found while working on this.

1: Block Displays are not considered Living Entities. This means you cannot use them as casters in Magic Spells, so I needed to try to find a nearby entity to trigger the spell instead on the Display Entities.
  This also caused an issue with the CloneMoved passive listener. Since the Block Display is not a Living Entity it will not ever trigger an Entity Move event.

This leads to a few issues. 
When it comes to targeted spells, I don't believe MS supports not LivingEntities as targets. Might need a rework of some kind to solve this. Or I just don't know anything about MS (Both very possible since I have only slightly used the plugin)