### PR TITLE
Mounts despawn on reload & RightClick option to Pulsar Spells

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -703,6 +703,10 @@ public class Subspell {
 		return success;
 	}
 
+	public void setCastMode(CastMode mode){
+		this.mode = mode;
+	}
+
 	public enum CastMode {
 
 		HARD("hard", "h"),

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -284,8 +284,25 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 	@Override
 	public void turnOff() {
 		for (LivingEntity entity : entities) {
-			entity.remove();
+			List<Entity> forRemoval = new ArrayList<>();
+			Entity _ent = entity;
+			Entity _riding = entity.getVehicle();
+
+			while(!_ent.getPassengers().isEmpty()){
+				forRemoval.add(_ent);
+				_ent = _ent.getPassengers().get(0);
+			}
+			while(_riding != null){
+				forRemoval.add(_riding);
+				_riding = _riding.getVehicle();
+			}
+
+			for(Entity ent : forRemoval){
+				ent.remove();
+			}
+			_ent.remove();
 		}
+
 		ticker.stop();
 		entities.clear();
 		pulsers.clear();


### PR DESCRIPTION
Fixed mounts not being removed on plugin reload (only main entity was removed no others)

Added right-click functionality to Pulsar Spells
You can now define a list of spells that are cast on right-click instead of only on a timer!
